### PR TITLE
プルリクエストマージ時に Discord へ通知を送る GitHub Actions を作成

### DIFF
--- a/.github/workflows/github_notification.yaml
+++ b/.github/workflows/github_notification.yaml
@@ -1,0 +1,22 @@
+name: github notification
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  pull_request_merged:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Need to incorporate changes
+        uses: appleboy/discord-action@0.0.3
+        with:
+          webhook_id: ${{ secrets.DISCORD_WEBHOOK_ID }}
+          webhook_token: ${{ secrets.DISCORD_WEBHOOK_TOKEN }}
+          username: "ぎっとはぶちゃん"
+          message: "
+@everyone\n
+[${{ github.event.pull_request.title }}](${{ github.event.pull_request.html_url }})\n
+のマージを完了しました。mainの内容を各ブランチへ取り込んでおいてください
+"


### PR DESCRIPTION
## 関連

なし

## 変更の概要

<!--
- 変更の概要を選択してください
- 複数選択可
 -->

-   [ ] フロントエンド
-   [ ] バックエンド
-   [ ] 機能関連
-   [ ] バグ修正
-   [ ] リファクタリング
-   [ ] ドキュメント
-   [x] その他

## 変更の詳細

**`.github/workflows/github_notification.yaml`**

- Pull Requests マージ時に Discord へ通知を送信する

## 動作確認

- actコマンドでプルリクエストをイベントとしたアクションで正常に動作していることを確認

## その他

なし