### PR TITLE
feat: PCのキーボードでもプレイヤーが動作するように変更

### DIFF
--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MessDetectorOptionsConfiguration">
+    <option name="transferred" value="true" />
+  </component>
+  <component name="PHPCSFixerOptionsConfiguration">
+    <option name="transferred" value="true" />
+  </component>
+  <component name="PHPCodeSnifferOptionsConfiguration">
+    <option name="highlightLevel" value="WARNING" />
+    <option name="transferred" value="true" />
+  </component>
+  <component name="PhpStanOptionsConfiguration">
+    <option name="transferred" value="true" />
+  </component>
+  <component name="PsalmOptionsConfiguration">
+    <option name="transferred" value="true" />
+  </component>
+</project>

--- a/.idea/susumukun.iml
+++ b/.idea/susumukun.iml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="SonarLintModuleSettings">
+    <option name="uniqueId" value="587737f0-4879-4769-8807-fe6d20308569" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="3932005a-315c-46f6-b2b7-27e2ec1753b7" name="変更" comment="">
+      <change afterPath="$PROJECT_DIR$/.idea/php.xml" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/.idea/susumukun.iml" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/.idea/vcs.xml" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/features/game/characters/player/index.ts" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/features/game/characters/player/index.ts" afterDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="ComposerSettings">
+    <execution />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="GitToolBoxStore">
+    <option name="recentBranches">
+      <RecentBranches>
+        <option name="branchesForRepo">
+          <list>
+            <RecentBranchesForRepo>
+              <option name="branches">
+                <list>
+                  <RecentBranch>
+                    <option name="branchName" value="feature/pc-keyboard-actions" />
+                    <option name="lastUsedInstant" value="1696497195" />
+                  </RecentBranch>
+                  <RecentBranch>
+                    <option name="branchName" value="main" />
+                    <option name="lastUsedInstant" value="1696495889" />
+                  </RecentBranch>
+                  <RecentBranch>
+                    <option name="branchName" value="PR28" />
+                    <option name="lastUsedInstant" value="1696490456" />
+                  </RecentBranch>
+                  <RecentBranch>
+                    <option name="branchName" value="PR27" />
+                    <option name="lastUsedInstant" value="1696482389" />
+                  </RecentBranch>
+                  <RecentBranch>
+                    <option name="branchName" value="PR26" />
+                    <option name="lastUsedInstant" value="1696482086" />
+                  </RecentBranch>
+                </list>
+              </option>
+              <option name="repositoryRootUrl" value="file://$PROJECT_DIR$" />
+            </RecentBranchesForRepo>
+          </list>
+        </option>
+      </RecentBranches>
+    </option>
+  </component>
+  <component name="GithubProjectSettings">
+    <option name="branchProtectionPatterns">
+      <list>
+        <option value="main" />
+      </list>
+    </option>
+  </component>
+  <component name="MarkdownSettingsMigration">
+    <option name="stateVersion" value="1" />
+  </component>
+  <component name="ProjectColorInfo">{
+  &quot;associatedIndex&quot;: 6
+}</component>
+  <component name="ProjectId" id="2WIKZK5LYavx88M9iPck90mm67s" />
+  <component name="ProjectViewState">
+    <option name="autoscrollToSource" value="true" />
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="openDirectoriesWithSingleClick" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "RunOnceActivity.OpenProjectViewOnStart": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.laravel-idea.search-composer-json": "true",
+    "WebServerToolWindowFactoryState": "false",
+    "git-widget-placeholder": "feature/pc-keyboard-actions",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "settings.editor.selected.configurable": "project.propVCSSupport.Confirmation",
+    "vue.rearranger.settings.migration": "true"
+  }
+}]]></component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="アプリケーションレベル" UseSingleDictionary="true" transferred="true" />
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="デフォルトタスク">
+      <changelist id="3932005a-315c-46f6-b2b7-27e2ec1753b7" name="変更" comment="" />
+      <created>1696414710197</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1696414710197</updated>
+      <workItem from="1696414711193" duration="35000" />
+      <workItem from="1696481879934" duration="3610000" />
+      <workItem from="1696489398366" duration="5778000" />
+    </task>
+    <servers />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+  <component name="VcsManagerConfiguration">
+    <option name="SHOW_DIRTY_RECURSIVELY" value="true" />
+  </component>
+</project>

--- a/frontend/src/features/game/characters/player/index.ts
+++ b/frontend/src/features/game/characters/player/index.ts
@@ -44,6 +44,11 @@ export default class Player {
     animation: Animation | null = null;
 
     /**
+     * @var キーボードのカーソルキー
+     */
+    cursors?: Phaser.Types.Input.Keyboard.CursorKeys;
+
+    /**
      * コンストラクタ
      *
      * @param {Phaser.Scene} scene シーン
@@ -77,6 +82,7 @@ export default class Player {
     create(objects?: Phaser.Physics.Arcade.StaticGroup[]): void {
         // プレイヤーとそのアニメーションの宣言
         this.object = new Character(this.scene, window.innerWidth / 2, window.innerHeight - 80, "susumu");
+        this.cursors = this.scene.input.keyboard?.createCursorKeys();
         this.animation = {
             turn: new TurnAnimation(this.scene, this),
             left: new LeftAnimation(this.scene, this),
@@ -98,6 +104,32 @@ export default class Player {
         for (const object of objects ?? []) {
             this.object.collider(object);
         }
+
+        this.cursors?.left?.on("down", () => {
+            this.animation?.left.update();
+            this.object?.setVelocityX(-160);
+        });
+
+        this.cursors?.right?.on("down", () => {
+            this.animation?.right.update();
+            this.object?.setVelocityX(160);
+        })
+
+        this.cursors?.up?.on("down", () => {
+            if (this.object?.body?.touching.down) {
+                this.object?.setVelocityY(-400);
+            }
+        })
+
+        this.cursors?.left?.on("up", () => {
+            this.animation?.turn.update();
+            this.object?.setVelocityX(0);
+        })
+
+        this.cursors?.right?.on("up", () => {
+            this.animation?.turn.update();
+            this.object?.setVelocityX(0);
+        })
     }
     /**
      * x方向の速度の上限・下限値を設定する
@@ -110,7 +142,6 @@ export default class Player {
             this.object?.setVelocityX(Phaser.Math.Clamp(this.object?.body.velocity.x , min, max));
         }
     }
-
 
     /**
     * 削除処理


### PR DESCRIPTION
## 関連

なし

## 変更の概要

<!--
- 変更の概要を選択してください
- 複数選択可
 -->

-   [x] フロントエンド
-   [ ] バックエンド
-   [x] 機能関連
-   [ ] バグ修正
-   [ ] リファクタリング
-   [ ] ドキュメント
-   [ ] その他

## 変更の詳細

- キーボードイベントを作成し，キーボードでプレイヤーが動作する様に変更

## 動作確認

- キーボードとボタンの両方でプレイヤーの操作ができることを確認

## その他

なし