### PR TITLE
スコア表示ページ作成（デザイン無視）

### DIFF
--- a/frontend/src/features/scores/api/index.ts
+++ b/frontend/src/features/scores/api/index.ts
@@ -1,0 +1,2 @@
+export * from "./read";
+export * from "./store";

--- a/frontend/src/features/scores/api/read.ts
+++ b/frontend/src/features/scores/api/read.ts
@@ -1,18 +1,22 @@
 import { axios } from "../../../lib/axios";
+import {ScoreEntity} from "../../../types";
+import {AxiosError, AxiosResponse} from "axios";
 
 /**
  * スコアを取得する
  *
  * @param {string} mode ソートモード (ASC: 昇順, DESC: 降順)
- * @returns {void} 戻り値無し
+ * @returns {Promise<ScoreEntity[] | []>} 戻り値無し
  */
-export const getScoresApi = (mode?: string): void => {
-    axios
+export const getScoresApi = async (mode?: string): Promise<ScoreEntity[] | []> => {
+    return await axios
         .get("/api/scores", {
             params: {
                 mode: mode,
             },
-        })
-        .then((response) => (process.env.NODE_ENV === "development" ? console.log(response.data) : null))
-        .catch((error) => (process.env.NODE_ENV === "development" ? console.log(error) : null));
+        }).then((response: AxiosResponse<{data: ScoreEntity[]}>) => {
+            return response.data.data;
+        }).catch((error: AxiosError) => {
+            return [];
+        });
 };

--- a/frontend/src/features/scores/api/store.ts
+++ b/frontend/src/features/scores/api/store.ts
@@ -1,18 +1,23 @@
 import { axios } from "../../../lib/axios";
+import Axios, {AxiosError, AxiosResponse} from "axios";
 
 /**
  * スコアを保存する
  *
  * @param {string} nickname ニックネーム
  * @param {number} score スコア
- * @returns {void} 戻り値無し
+ * @returns {Promise<void>} 戻り値無し
  */
-export const storeScoresApi = (nickname: string, score: number): void => {
-    axios
+export const storeScoresApi = async (nickname: string, score: number): Promise<void> => {
+    return await axios
         .post("/api/scores", {
             nickname: nickname,
             score: score,
         })
-        .then((response) => (process.env.NODE_ENV === "development" ? console.log(response.data) : null))
-        .catch((error) => (process.env.NODE_ENV === "development" ? console.log(error) : null));
+        .then((response: AxiosResponse) => {
+             //
+        })
+        .catch((error: AxiosError) => {
+            alert("スコアの保存に失敗しました")
+        });
 };

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -102,7 +102,7 @@ export const Home = () => {
                                 </Box>
                             </Box>
                         </Modal>
-                        <Button variant="contained" color='inherit' sx={{ margin: 3 }}> スコア確認</Button>
+                        <Button href="/scores" variant="contained" color='inherit' sx={{ margin: 3 }}> スコア確認</Button>
                     </Grid>
                 </Grid>
             </Box>

--- a/frontend/src/pages/Scores.tsx
+++ b/frontend/src/pages/Scores.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import {MainLayout} from "../components/Layout/MainLayout";
+import {DESC} from "../config";
+import {ScoreEntity} from "../types";
+import {is_set} from "../utils/isType";
+import {getScoresApi, storeScoresApi} from "../features/scores/api";
+
+/**
+ * スコア画面
+ *
+ * @return {JSX.Element}
+ */
+export default function Scores(): JSX.Element {
+    const [scores, setScores] = React.useState<ScoreEntity[]>([]);
+
+    // スコアを取得
+    React.useEffect(() => {
+        getScoresApi(DESC).then((res: ScoreEntity[]) => {
+            setScores(res);
+        });
+    }, []);
+
+    // スコアを表示
+    const scoreList = scores.map((score: ScoreEntity, index: number) => {
+        return (
+            <div key={index}>
+                <div>{score.nickname}</div>
+                <div>{score.score}</div>
+            </div>
+        );
+    });
+
+    return (
+        <MainLayout title={"走れ！すすむ君！ - スコア"}>
+            <button onClick={() => storeScoresApi(
+                Math.random().toString(32).substring(2),
+                Math.floor(Math.random() * 100 + 1)
+            )}>Debug用 - ランダムデータ保存</button>
+            <div>
+                {is_set<ScoreEntity[]>(scores) && scoreList}
+            </div>
+        </MainLayout>
+    );
+}

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { Home } from "../pages/Home";
 import { Gamewindow } from "../pages/Gamewindow";
+import Scores from "../pages/Scores";
 
 export const AppRoutes = () => {
     return (
@@ -8,6 +9,7 @@ export const AppRoutes = () => {
             <Routes>
                 <Route index element={Home()} />
                 <Route path="/Gamewindow" element={Gamewindow()} />
+                <Route path="/scores" element={Scores()} />
             </Routes>
         </BrowserRouter>
     );

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,0 +1,10 @@
+/**
+ * スコアのエンティティ
+ *
+ * @property {string} nickname ニックネーム
+ * @property {number} score スコア
+ */
+export type ScoreEntity = {
+    nickname: string;
+    score: number;
+}

--- a/frontend/src/utils/isType.ts
+++ b/frontend/src/utils/isType.ts
@@ -1,0 +1,9 @@
+/**
+ * 値が存在するかどうかを判定する
+ *
+ * @param {undefined} value 存在するかどうかの判定を行う値
+ * @returns {boolean} 存在するかどうか
+ */
+export function is_set<T>(value: unknown): value is T {
+  return value !== undefined && value !== null;
+}


### PR DESCRIPTION
## 関連

なし

## 変更の概要

<!--
- 変更の概要を選択してください
- 複数選択可
 -->

-   [x] フロントエンド
-   [ ] バックエンド
-   [x] 機能関連
-   [ ] バグ修正
-   [ ] リファクタリング
-   [ ] ドキュメント
-   [ ] その他

## 変更の詳細

- scoresページを作成して，バックエンドで保存されたスコアを表示する
- scoresページにデバッグ用のランダムスコア保存ボタンを追加
- homeページから「スコア確認」ボタンでscoreページへ移動できる様に

## 動作確認

- 保存されているスコアが画面に表示されることを確認

## その他

デザインは無視しています