### PR TITLE
制限時間の追加

### DIFF
--- a/frontend/src/features/game/scenes/MainScene.ts
+++ b/frontend/src/features/game/scenes/MainScene.ts
@@ -54,6 +54,16 @@ export default class MainScene extends Phaser.Scene {
       */
      private score: number = 0;
      private scoreText: Phaser.GameObjects.Text | null = null;
+
+      /**
+     * @var 制限時間 (秒)
+     */
+    private timeLimit: number = 180; // 3分間
+
+    /**
+     * @var テキストオブジェクト
+     */
+    private timeObject: Phaser.GameObjects.Text;
     /**
      * コンストラクタ
      *
@@ -70,6 +80,13 @@ export default class MainScene extends Phaser.Scene {
 
 
         this.goal = new Goal(this, "goal");
+
+        this.timeObject = {} as Phaser.GameObjects.Text;
+
+        this.events = new Phaser.Events.EventEmitter();
+
+        this.events.on('update', this.updateTimer, this);
+
     }
 
     /**
@@ -123,6 +140,34 @@ export default class MainScene extends Phaser.Scene {
 
         // ワールドの境界を設定する
         this.physics.world.setBounds(stage.stage_x, stage.stage_y, stage.width, stage.height);
+
+        this.cameras.main.setBounds(stage.stage_x, stage.stage_y, stage.width, stage.height);
+        this.cameras.main.setScroll(0, 0);  // カメラのスクロールを0に設定
+
+
+
+        this.timeObject = this.add.text(
+            window.innerWidth - 20,  // 固定のX座標
+            20,  // 固定のY座標
+            '',
+            {
+                fontFamily: 'Arial',
+                fontSize: '24px',
+                color: '#ffffff'
+            }
+        );
+        this.timeObject.setScrollFactor(0);  // スクロールに影響を受けないように設定
+        this.timeObject.setOrigin(1, 0);  // テキストの原点を左上に設定
+
+        this.time.addEvent({
+            delay: 1000,  // 1000ミリ秒ごと（1秒ごと）
+            loop: true,
+            callback: this.updateTimer,
+            callbackScope: this
+        });
+
+
+        this.updateTimerDisplay();
 
         // 初期画面に敵を配置
         for (let i = 0; i < 5; i++) {
@@ -190,6 +235,19 @@ export default class MainScene extends Phaser.Scene {
     }
     getScore(): number {
         return this.score;
+    }
+
+    private updateTimer(): void {
+        this.timeLimit--;
+        this.updateTimerDisplay();
+
+        if (this.timeLimit <= 0) {
+            this.startScene("GameOver");
+        }
+    }
+
+    private updateTimerDisplay(): void {
+        this.timeObject.setText(`Time: ${this.timeLimit} s`);
     }
 
     /**


### PR DESCRIPTION
## 関連
https://github.com/Obanyan2023/susumukun/issues/46#issue-1939361109
<!--
- 関連するPull request, Issueなど
-->

## 変更の概要
制限時間を仮で設定（１８０秒）し、右上に表示させた。
制限時間のテキストを右上に固定させ、カメラの影響を受けないようにした。
制限時間が過ぎるとゲームオーバーシーンに遷移するようにした。

<!--
- 変更の概要を選択してください
- 複数選択可
 -->

-   [x] フロントエンド
-   [ ] バックエンド
-   [ ] 機能関連
-   [ ] バグ修正
-   [ ] リファクタリング
-   [ ] ドキュメント
-   [ ] その他

## 変更の詳細

<!--
- 変更の詳細をなるべく具体的に記載して下さい
 -->

## 動作確認
制限時間を過ぎるとゲームオーバーになるか確認した。
ゲームオーバーした後リトライし、時間がきちんと１８０秒に戻っているか確認した。

その他キャラの挙動などにバグが無いか動作確認した。

<!--
- どのような動作確認をしたのか？見つかった課題等はあるか？
-->

## その他
時間設定やテキストの位置、サイズ、フォントなどは後日確認をとりながら調整します
<!--
- 伝えておくべき事や，補足資料などがあれば自由に記載して下さい
-->