### PR TITLE
ゲームオーバ後の敵の衝突判定の修正

### DIFF
--- a/frontend/src/features/game/characters/enemy/index.ts
+++ b/frontend/src/features/game/characters/enemy/index.ts
@@ -43,7 +43,7 @@ export default class Enemy {
 
     update(): void{
        if(this.name=="error-caterpillar"){
-        var random=Phaser.Math.Between(1,50);
+        let random=Phaser.Math.Between(1,50);
                 if(this.object?.body?.velocity!==undefined && random === 1){
                     this.object?.setVelocityX(this.object.body?.velocity.x * -1 );
             }
@@ -146,8 +146,9 @@ export default class Enemy {
                 let mainscene: MainScene | null = null;
                 if (this.scene instanceof MainScene) {
                     mainscene = this.scene;
-                } 
-                if (player.object !== null && this.object !== null && player.object.y < this.object.y) {
+                }
+                // プレイヤが死亡していないかつ，プレイヤーが敵より上にいる場合
+                if (player.object !== null && this.object !== null && player.object.visible && player.object.y < this.object.y) {
                     player.object.setVelocityY(-200);
                     this.object.setOrigin(0.5, 0);
                     this.object.destroy();

--- a/frontend/src/features/game/scenes/MainScene.ts
+++ b/frontend/src/features/game/scenes/MainScene.ts
@@ -188,12 +188,9 @@ export default class MainScene extends Phaser.Scene {
         this.score += score;
         this.scoreText?.setText(`Score: ${this.score}`)
     }
-    getScore(): number {
-        return this.score;
-    }
-
     /**
      * ゲームオーバー画面に遷移する 次のシーンにデータを引き継ぐ
+     * @param {string} key 次のシーンのキー
      * @returns {void} 戻り値なし
      */
     startScene(key:String) : void {


### PR DESCRIPTION
## 関連

<!--
- 関連するPull request, Issueなど
-->

## 変更の概要

<!--
- 変更の概要を選択してください
- 複数選択可
 -->

-   [x] フロントエンド
-   [ ] バックエンド
-   [ ] 機能関連
-   [x] バグ修正
-   [ ] リファクタリング
-   [ ] ドキュメント
-   [ ] その他

## 変更の詳細

<!--
- 変更の詳細をなるべく具体的に記載して下さい
 -->
- 敵にあたりプレイヤーが亡くなった(透明)あとに、透明状態のプレイヤが敵を踏んだ場合に、敵を倒せるバグを直した。(敵を倒せる条件にプレイヤが可視状態である(透明でない)条件を追加した。)
- 以前のタスクで、デバックのために用意し、消し忘れたgetScore関数を削除した。
- startScene関数の引数についてのコメントを追加した。
## 動作確認

<!--
- どのような動作確認をしたのか？見つかった課題等はあるか？
-->
- 敵に衝突後、踏んでも敵オブジェクトが消失しないことを確認した。

## その他

<!--
- 伝えておくべき事や，補足資料などがあれば自由に記載して下さい
-->