### PR TITLE
スコアをサーバに送信

### DIFF
--- a/frontend/src/features/game/index.ts
+++ b/frontend/src/features/game/index.ts
@@ -1,7 +1,6 @@
 import Phaser from "phaser";
 import GameOverScene from "./scenes/GameOverScene";
 import MainScene from "./scenes/MainScene";
-import GameClearImage from "./components/images/GameClearImage";
 import GameClearScene from "./scenes/GameClearScene";
 
 /**

--- a/frontend/src/features/game/scenes/GameClearScene.ts
+++ b/frontend/src/features/game/scenes/GameClearScene.ts
@@ -1,61 +1,18 @@
-import Phaser from "phaser";
 import GameClearImage from "../components/images/GameClearImage";
 import TmpButton from "../components/buttons/TmpButton";
+import GameEndScene from "./GameEndScene";
 
 /**
- * ゲームオーバーシーン
+ * ゲームクリアシーン
  */
-export default class GameClearScene extends Phaser.Scene {
-    /**
-     * @var ゲームオーバー画像
-     */
-    private gameClearImage: GameClearImage;
-
-    /**
-     * @var ゲーム再スタートボタン
-     */
-    private tmpButton: TmpButton;
-
-    /**
-     * @var スコア
-     */
-    private score: number = 0;
-
+export default class GameClearScene extends GameEndScene {
     /**
      * コンストラクタ
      */
     constructor() {
-        super({ key: "GameClear" });
+        super("GameClear");
 
-        this.gameClearImage = new GameClearImage(this);
+        this.gameEndImage = new GameClearImage(this);
         this.tmpButton = new TmpButton(this);
-    }
-
-    /**
-     * データの引き継ぎ
-     */
-    init(data:any) {
-        this.score = data.score;
-    }
-    /**
-     * 画像を読み込む
-     *
-     * @returns {void} 戻り値なし
-     */
-    preload(): void {
-        this.gameClearImage.preload();
-    }
-
-    /**
-     * 画像やボタンを作成する
-     */
-    create(): void {
-        this.gameClearImage.create();
-        this.tmpButton.create();
-
-        const scoreText = this.add.text(window.innerWidth /2 , window.innerHeight /4, `Score: ${this.score}`, {fontSize: "50px"});
-        scoreText.setOrigin(0.5);
-
-        console.log("GameClear!!");
     }
 }

--- a/frontend/src/features/game/scenes/GameEndScene.ts
+++ b/frontend/src/features/game/scenes/GameEndScene.ts
@@ -1,0 +1,70 @@
+import Phaser from "phaser";
+import TmpButton from "../components/buttons/TmpButton";
+import GameOverImage from "../components/images/GameOverImage";
+import GameClearImage from "../components/images/GameClearImage";
+import { storeScoresApi } from "../../scores/api";
+
+export default class GameEndScene extends Phaser.Scene {
+    /**
+     * @var ゲーム終了画像
+     */
+    protected gameEndImage: GameOverImage | GameClearImage;
+
+    /**
+     * @var ゲーム再スタートボタン
+     */
+    protected tmpButton: TmpButton;
+
+    /**
+     * @var スコア
+     */
+    protected score: number = 0;
+
+    /**
+     * コンストラクタ
+     *
+     * @param {string} key シーンのキー
+     */
+    constructor(key: string) {
+        super({ key: key });
+
+        this.tmpButton = new TmpButton(this);
+        this.gameEndImage = new GameOverImage(this);
+    }
+
+    /**
+     * データの引き継ぎ
+     *
+     * @param {any} data 引き継ぎデータ
+     * @returns {void} 戻り値なし
+     */
+    init(data: any): void {
+        this.score = data.score;
+    }
+
+    /**
+     * 画像を読み込む
+     *
+     * @returns {void} 戻り値なし
+     */
+    preload(): void {
+        this.gameEndImage.preload();
+    }
+
+    /**
+     * 画像やボタンを作成する
+     *
+     * @returns {void} 戻り値なし
+     */
+    create(): void {
+        this.gameEndImage.create();
+        this.tmpButton.create();
+
+        const scoreText = this.add.text(window.innerWidth / 2, window.innerHeight / 4, `Score: ${this.score}`, {
+            fontSize: "50px",
+        });
+        scoreText.setOrigin(0.5);
+
+        storeScoresApi(Math.random().toString(32).substring(2), this.score);
+    }
+}

--- a/frontend/src/features/game/scenes/GameOverScene.ts
+++ b/frontend/src/features/game/scenes/GameOverScene.ts
@@ -1,64 +1,18 @@
-import Phaser from "phaser";
 import GameOverImage from "../components/images/GameOverImage";
 import TmpButton from "../components/buttons/TmpButton";
+import GameEndScene from "./GameEndScene";
 
 /**
  * ゲームオーバーシーン
  */
-export default class GameOverScene extends Phaser.Scene {
-    /**
-     * @var ゲームオーバー画像
-     */
-    private gameOverImage: GameOverImage;
-
-    /**
-     * @var ゲーム再スタートボタン
-     */
-    private tmpButton: TmpButton;
-    /**
-     * @var スコア
-     */
-    public score: number | null = null;
-
+export default class GameOverScene extends GameEndScene {
     /**
      * コンストラクタ
      */
     constructor() {
-        super({ key: "GameOver" });
+        super("GameOver");
 
-        this.gameOverImage = new GameOverImage(this);
+        this.gameEndImage = new GameOverImage(this);
         this.tmpButton = new TmpButton(this);
-    }
-    
-
-    /**
-     * 画像を読み込む
-     *
-     * @returns {void} 戻り値なし
-     */
-    preload(): void {
-        this.gameOverImage.preload();
-    }
-
-    init(data:any): void {
-        console.log(data);
-        this.score = data.score;
-    }
-
-    /**
-     * 画像やボタンを作成する
-     */
-    create(): void {
-        this.gameOverImage.create();
-        this.tmpButton.create();
-
-        const scoreText = this.add.text(window.innerWidth /2 , window.innerHeight /4, `Score: ${this.score}`, {fontSize: "50px"});
-        scoreText.setOrigin(0.5);
-
-        console.log("GameOver!!");
-    }
-
-    update() {
-
     }
 }

--- a/frontend/src/pages/Scores.tsx
+++ b/frontend/src/pages/Scores.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import {MainLayout} from "../components/Layout/MainLayout";
-import {DESC} from "../config";
-import {ScoreEntity} from "../types";
-import {is_set} from "../utils/isType";
-import {getScoresApi, storeScoresApi} from "../features/scores/api";
+import { MainLayout } from "../components/Layout/MainLayout";
+import { DESC } from "../config";
+import { ScoreEntity } from "../types";
+import { is_set } from "../utils/isType";
+import { getScoresApi } from "../features/scores/api";
 
 /**
  * スコア画面
@@ -32,10 +32,6 @@ export default function Scores(): JSX.Element {
 
     return (
         <MainLayout title={"走れ！すすむ君！ - スコア"}>
-            <button onClick={() => storeScoresApi(
-                Math.random().toString(32).substring(2),
-                Math.floor(Math.random() * 100 + 1)
-            )}>Debug用 - ランダムデータ保存</button>
             <div>
                 {is_set<ScoreEntity[]>(scores) && scoreList}
             </div>


### PR DESCRIPTION
## 関連

- #37 

## 変更の概要

<!--
- 変更の概要を選択してください
- 複数選択可
 -->

-   [x] フロントエンド
-   [ ] バックエンド
-   [x] 機能関連
-   [ ] バグ修正
-   [x] リファクタリング
-   [ ] ドキュメント
-   [ ] その他

## 変更の詳細

- ゲーム終了時にスコアをサーバに送信
- ゲームクリアとゲームオーバーの共通部分を１つにまとめる
- スコアページのデバッグ用ボタンを削除

## 動作確認

- ゲームクリア時にスコアがサーバに送信され，スコアページで確認できた
- ゲームーバー時にスコアがサーバに送信され，スコアページで確認できた

## その他

なし