### PR TITLE
敵の量を現在を基準にして約1倍・1/2倍・1/4倍となるような難易度をそれぞれ作成

### DIFF
--- a/frontend/src/features/game/scenes/MainScene.ts
+++ b/frontend/src/features/game/scenes/MainScene.ts
@@ -39,23 +39,23 @@ export default class MainScene extends Phaser.Scene {
      */
     private jumpButton: MoveJumpButton;
 
-     /**
+    /**
      * @var ゴール
      */
-     private goal: Goal;
+    private goal: Goal;
 
-     /**
-      * @var 前回のカメラ位置
-      */
-     private before_x: number | undefined;
+    /**
+     * @var 前回のカメラ位置
+     */
+    private before_x: number | undefined;
 
-     /**
-      * @var スコア
-      */
-     private score: number = 0;
-     private scoreText: Phaser.GameObjects.Text | null = null;
+    /**
+     * @var スコア
+     */
+    private score: number = 0;
+    private scoreText: Phaser.GameObjects.Text | null = null;
 
-      /**
+    /**
      * @var 制限時間 (秒)
      */
     private timeLimit: number = 180; // 3分間
@@ -64,6 +64,12 @@ export default class MainScene extends Phaser.Scene {
      * @var テキストオブジェクト
      */
     private timeObject: Phaser.GameObjects.Text;
+
+    /**
+     * @var 難易度
+     */
+    private difficult: number = 2;
+
     /**
      * コンストラクタ
      *
@@ -78,15 +84,15 @@ export default class MainScene extends Phaser.Scene {
         this.rightButton = new MoveRightButton(this);
         this.jumpButton = new MoveJumpButton(this);
 
-
         this.goal = new Goal(this, "goal");
 
         this.timeObject = {} as Phaser.GameObjects.Text;
 
         this.events = new Phaser.Events.EventEmitter();
 
-        this.events.on('update', this.updateTimer, this);
+        this.events.on("update", this.updateTimer, this);
 
+        this.difficult = Number(localStorage.getItem("difficult"));
     }
 
     /**
@@ -117,7 +123,12 @@ export default class MainScene extends Phaser.Scene {
         this.player.create([this.stage.ground.platform.object] as Phaser.Physics.Arcade.StaticGroup[]);
 
         // ゴールの作成
-        this.goal.create([this.stage.ground.platform.object] as Phaser.Physics.Arcade.StaticGroup[], this.player,  this.cameras.main.width + 3100, 30)
+        this.goal.create(
+            [this.stage.ground.platform.object] as Phaser.Physics.Arcade.StaticGroup[],
+            this.player,
+            this.cameras.main.width + 3100,
+            30
+        );
 
         // ボタンの作成
         this.leftButton.create(this.player);
@@ -125,7 +136,7 @@ export default class MainScene extends Phaser.Scene {
         this.jumpButton.create(this.player);
 
         // スコア表示
-        this.scoreText = this.add.text(10, 10, `Score: ${this.score}`, {fontSize: "40px",});
+        this.scoreText = this.add.text(10, 10, `Score: ${this.score}`, { fontSize: "40px" });
         this.scoreText.setScrollFactor(0);
 
         const stage = {
@@ -142,37 +153,39 @@ export default class MainScene extends Phaser.Scene {
         this.physics.world.setBounds(stage.stage_x, stage.stage_y, stage.width, stage.height);
 
         this.cameras.main.setBounds(stage.stage_x, stage.stage_y, stage.width, stage.height);
-        this.cameras.main.setScroll(0, 0);  // カメラのスクロールを0に設定
-
-
+        this.cameras.main.setScroll(0, 0); // カメラのスクロールを0に設定
 
         this.timeObject = this.add.text(
-            window.innerWidth - 20,  // 固定のX座標
-            20,  // 固定のY座標
-            '',
+            window.innerWidth - 20, // 固定のX座標
+            20, // 固定のY座標
+            "",
             {
-                fontFamily: 'Arial',
-                fontSize: '24px',
-                color: '#ffffff'
+                fontFamily: "Arial",
+                fontSize: "24px",
+                color: "#ffffff",
             }
         );
-        this.timeObject.setScrollFactor(0);  // スクロールに影響を受けないように設定
-        this.timeObject.setOrigin(1, 0);  // テキストの原点を左上に設定
+        this.timeObject.setScrollFactor(0); // スクロールに影響を受けないように設定
+        this.timeObject.setOrigin(1, 0); // テキストの原点を左上に設定
 
         this.time.addEvent({
-            delay: 1000,  // 1000ミリ秒ごと（1秒ごと）
+            delay: 1000, // 1000ミリ秒ごと（1秒ごと）
             loop: true,
             callback: this.updateTimer,
-            callbackScope: this
+            callbackScope: this,
         });
-
 
         this.updateTimerDisplay();
 
         // 初期画面に敵を配置
-        for (let i = 0; i < 5; i++) {
-            let newEnemy = new Enemy(this, Enemy.get_enemyName());
-            newEnemy.create([this.stage.ground.platform.object] as Phaser.Physics.Arcade.StaticGroup[], this.player, Phaser.Math.Between(window.innerWidth / 3, window.innerWidth) , window.innerHeight/3 * 2);
+        for (let i = 0; i < 6 / this.difficult; i++) {
+            const newEnemy = new Enemy(this, Enemy.get_enemyName());
+            newEnemy.create(
+                [this.stage.ground.platform.object] as Phaser.Physics.Arcade.StaticGroup[],
+                this.player,
+                Phaser.Math.Between(window.innerWidth / 3, window.innerWidth),
+                (window.innerHeight / 3) * 2
+            );
             this.enemyGroup.push(newEnemy);
         }
     }
@@ -186,11 +199,10 @@ export default class MainScene extends Phaser.Scene {
         this.player.update();
 
         // プレイヤー落下時にゲームオーバー画面に遷移する
-        if (!this.physics.world.bounds.contains(this.cameras.main.width / 2, this.player.object?.y as number + 1)) {
-            this.player.destroy(
-               () => {
-                    this.startScene('GameOver');
-               }, 1000 )
+        if (!this.physics.world.bounds.contains(this.cameras.main.width / 2, (this.player.object?.y as number) + 1)) {
+            this.player.destroy(() => {
+                this.startScene("GameOver");
+            }, 1000);
         }
         this.player.callLimitVelocityX(-160, 160);
         this.enemy_update();
@@ -202,36 +214,42 @@ export default class MainScene extends Phaser.Scene {
      * @returns {void} 戻り値なし
      */
     enemy_update(): void {
-        if (this.player.object === null ) {
+        if (this.player.object === null) {
             return;
         }
 
-        let rand = Phaser.Math.Between(0, 70);
+        let rand = Phaser.Math.Between(0, 70 * this.difficult);
 
         let enemy_name = Enemy.get_enemyName();
-        if (this.before_x === undefined) { 
+        if (this.before_x === undefined) {
             this.before_x = this.cameras.main.scrollX;
         }
         if (this.cameras.main.scrollX > this.before_x && rand === 1) {
-            let newEnemy = new Enemy(this, enemy_name)
-            newEnemy.create([this.stage.ground.platform.object] as Phaser.Physics.Arcade.StaticGroup[], this.player, this.cameras.main.scrollX + window.innerWidth + 50 , window.innerHeight / 10 );
+            const newEnemy = new Enemy(this, enemy_name);
+            newEnemy.create(
+                [this.stage.ground.platform.object] as Phaser.Physics.Arcade.StaticGroup[],
+                this.player,
+                this.cameras.main.scrollX + window.innerWidth + 50,
+                window.innerHeight / 10
+            );
             this.enemyGroup.push(newEnemy);
             this.before_x = this.cameras.main.scrollX;
         }
 
         this.enemyGroup.forEach((enemy) => {
             enemy.update();
-            let height : number = 15;
-            if (!this.physics.world.bounds.contains(this.cameras.main.width / 2, enemy.object?.y as number + height)) {
+            let height: number = 15;
+            if (
+                !this.physics.world.bounds.contains(this.cameras.main.width / 2, (enemy.object?.y as number) + height)
+            ) {
                 enemy.object?.destroy();
             }
-        })
-
+        });
     }
 
     updateScore(score: number): void {
         this.score += score;
-        this.scoreText?.setText(`Score: ${this.score}`)
+        this.scoreText?.setText(`Score: ${this.score}`);
     }
     getScore(): number {
         return this.score;
@@ -255,10 +273,10 @@ export default class MainScene extends Phaser.Scene {
      * @param {string} key 次のシーンのキー
      * @returns {void} 戻り値なし
      */
-    startScene(key:String) : void {
+    startScene(key: String): void {
         const data = {
             score: this.score,
-        }
-        this.scene.start(`${key}`, data)
+        };
+        this.scene.start(`${key}`, data);
     }
 }

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -2,15 +2,19 @@ import { MainLayout } from "../components/Layout/MainLayout";
 import {
     Box,
     Button,
+    FormControl,
     Grid,
+    InputLabel,
+    MenuItem,
     Modal,
+    Select,
     Typography
 } from "@mui/material";
 import * as React from 'react';
 import Background from '../assets/images/image.jpg';
 import '../index.css'
 import { useState } from 'react';
-import {GameComponent} from "../components/Game";
+import { GameComponent } from "../components/Game";
 
 const style = {
     position: 'absolute' as 'absolute',
@@ -53,13 +57,13 @@ const head = () => {
 };
 
 export const Home = () => {
-    const [ isFullScreen, setIsFullScreen ] = React.useState<boolean>(document.fullscreenElement ? true : false);
+    const [isFullScreen, setIsFullScreen] = React.useState<boolean>(document.fullscreenElement ? true : false);
     const [open, setOpen] = React.useState(false);
 
     const handleOpen = () => setOpen(true);
     const handleClose = () => setOpen(false);
 
-    const handleGameStart = () => {
+    const handleGameStart = (difficult: number) => {
         if (document.fullscreenElement) {
             document.exitFullscreen();
         } else {
@@ -67,53 +71,61 @@ export const Home = () => {
         }
 
         setIsFullScreen(!isFullScreen);
+        localStorage.setItem("difficult", String(difficult));
     }
 
     const HomeComponent = () => (
-            <Box sx={image}>
-                <Grid container alignItems={"center"} direction={"column"} sx={{ overflow: 'hidden', height: '100vh', width: '100vw' }}>
-                    <Grid container spacing={2} sx={{ height: "30%" }} alignItems="center">
-                        <Grid item xs={12}>
-                            <Typography className="mfont" align="center" sx={{ fontFamily: 'Mochiy Pop P One', fontSize: 50 }}>
-                                {"走れ！すすむ君！"}
-                            </Typography>
-                        </Grid>
-                    </Grid>
-                    <Grid container alignItems="center" direction="column" sx={{ bottom: "10%" }} >
-                        <Button variant="contained" sx={{ margin: 3 }} onClick={() => handleGameStart()}>ゲームスタート</Button>
-                        <Button variant="contained" color='inherit' sx={{ margin: 3 }} onClick={handleOpen}>ルール説明</Button>
-                        <Modal
-                            open={open}
-                            onClose={handleClose}
-                            aria-labelledby="modal-modal-title"
-                            aria-describedby="modal-modal-description"
-                        >
-                            <Box sx={style}>
-                                <Typography id="modal-modal-title" variant="h6" component="h2">
-                                    ルール説明
-                                </Typography>
-                                <Typography id="modal-modal-description" sx={{ mt: 2 }}>
-                                    ・三回ミスしたらゲームオーバー<br />
-                                    ・ステージが変わるごとに体力は回復する<br />
-                                    ・スコアを他のプレイヤーと競う<br />
-                                    ・最高得点が10000 <br />
-                                    ・アイテム：100点（隠しアイテムは点数を高くする）<br />
-                                    ・敵：100点～（敵が強くなるたびに加算点数を増加させるから最高得点未定！敵の数によって決める) <br />
-                                </Typography>
-                                <Box sx={closebutton}>
-                                    <Button variant="contained" onClick={handleClose}>閉じる</Button>
-                                </Box>
-                            </Box>
-                        </Modal>
-                        <Button href="/scores" variant="contained" color='inherit' sx={{ margin: 3 }}> スコア確認</Button>
+        <Box sx={image}>
+            <Grid container alignItems={"center"} direction={"column"} sx={{ overflow: 'hidden', height: '100vh', width: '100vw' }}>
+                <Grid container spacing={2} sx={{ height: "30%" }} alignItems="center">
+                    <Grid item xs={12}>
+                        <Typography className="mfont" align="center" sx={{ fontFamily: 'Mochiy Pop P One', fontSize: 50 }}>
+                            {"走れ！すすむ君！"}
+                        </Typography>
                     </Grid>
                 </Grid>
-            </Box>
+                <Grid container alignItems="center" direction="column" sx={{ bottom: "10%" }} >
+                    <FormControl sx={{ width: 100 }}>
+                        <InputLabel >難易度</InputLabel>
+                        <Select>
+                            <MenuItem onClick={() => handleGameStart(1)}>Hard</MenuItem>
+                            <MenuItem onClick={() => handleGameStart(2)}>Normal</MenuItem>
+                            <MenuItem onClick={() => handleGameStart(4)}>Easy</MenuItem>
+                        </Select>
+                    </FormControl>
+                    <Button variant="contained" color='inherit' sx={{ margin: 3 }} onClick={handleOpen}>ルール説明</Button>
+                    <Modal
+                        open={open}
+                        onClose={handleClose}
+                        aria-labelledby="modal-modal-title"
+                        aria-describedby="modal-modal-description"
+                    >
+                        <Box sx={style}>
+                            <Typography id="modal-modal-title" variant="h6" component="h2">
+                                ルール説明
+                            </Typography>
+                            <Typography id="modal-modal-description" sx={{ mt: 2 }}>
+                                ・三回ミスしたらゲームオーバー<br />
+                                ・ステージが変わるごとに体力は回復する<br />
+                                ・スコアを他のプレイヤーと競う<br />
+                                ・最高得点が10000 <br />
+                                ・アイテム：100点（隠しアイテムは点数を高くする）<br />
+                                ・敵：100点～（敵が強くなるたびに加算点数を増加させるから最高得点未定！敵の数によって決める) <br />
+                            </Typography>
+                            <Box sx={closebutton}>
+                                <Button variant="contained" onClick={handleClose}>閉じる</Button>
+                            </Box>
+                        </Box>
+                    </Modal>
+                    <Button href="/scores" variant="contained" color='inherit' sx={{ margin: 3 }}> スコア確認</Button>
+                </Grid>
+            </Grid>
+        </Box >
     );
 
     return (
         <MainLayout title={"走れ！すすむ君！ - " + isFullScreen ? "ようこそ！" : "ゲーム"} head={head()}>
-            {isFullScreen ? <GameComponent/> : <HomeComponent/>}
+            {isFullScreen ? <GameComponent /> : <HomeComponent />}
         </MainLayout>
     )
 }


### PR DESCRIPTION
## 関連

- #64 

## 変更の概要

<!--
- 変更の概要を選択してください
- 複数選択可
 -->

-   [x] フロントエンド
-   [ ] バックエンド
-   [x] 機能関連
-   [ ] バグ修正
-   [ ] リファクタリング
-   [ ] ドキュメント
-   [ ] その他

## 変更の詳細

**`frontend/src/pages/Home.tsx`**

- ドロップダウンメニューを利用して３段階で難易度を選択可能に
- 難易度の元となる倍率値をローカルストレージに保存

**`frontend/src/features/game/scenes/MainScene.ts`**

- 敵の出現率を選択された３段階の難易度を元に，1倍・1/2倍・1/4倍となるように変更

## 動作確認

- それぞれの難易度で大体適切な敵の量であることを確認

## その他

なし