### PR TITLE
ゲームオーバーのときのスコアを8割にした

### DIFF
--- a/frontend/src/features/game/scenes/MainScene.ts
+++ b/frontend/src/features/game/scenes/MainScene.ts
@@ -274,6 +274,9 @@ export default class MainScene extends Phaser.Scene {
      * @returns {void} 戻り値なし
      */
     startScene(key: String): void {
+        if(key==="GameOver"){
+            this.score*=0.8;
+        }
         const data = {
             score: this.score,
         };


### PR DESCRIPTION
## 関連

<!--
- 関連するPull request, Issueなど
-->
https://github.com/Obanyan2023/susumukun/issues/62

## 変更の概要

<!--
- 変更の概要を選択してください
- 複数選択可
 -->

-   [x] フロントエンド
-   [ ] バックエンド
-   [ ] 機能関連
-   [ ] バグ修正
-   [ ] リファクタリング
-   [ ] ドキュメント
-   [ ] その他

## 変更の詳細
ゲームオーバーになった時のスコアを8割になるようにした
<!--
- 変更の詳細をなるべく具体的に記載して下さい
 -->

## 動作確認

<!--
- どのような動作確認をしたのか？見つかった課題等はあるか？
-->

## その他

<!--
- 伝えておくべき事や，補足資料などがあれば自由に記載して下さい
-->