### PR TITLE
スコア確認画面に閉じるボタンの追加

### DIFF
--- a/frontend/src/pages/Scores.tsx
+++ b/frontend/src/pages/Scores.tsx
@@ -126,6 +126,7 @@ export default function Scores(): JSX.Element {
                             )}
                         </div>
                     </div>
+                    <div><Button href="/" variant="contained" color='inherit' sx={{ margin: 3 }}> 閉じる</Button></div>
                 </Grid>
             </Box>
         </MainLayout>


### PR DESCRIPTION
## 関連

<!--
- 関連するPull request, Issueなど
-->
https://github.com/Obanyan2023/susumukun/issues/87
## 変更の概要

<!--
- 変更の概要を選択してください
- 複数選択可
 -->

-   [x] フロントエンド
-   [ ] バックエンド
-   [x] 機能関連
-   [ ] バグ修正
-   [ ] リファクタリング
-   [ ] ドキュメント
-   [ ] その他

## 変更の詳細

<!--
- 変更の詳細をなるべく具体的に記載して下さい
 -->
スコア画面に閉じるボタンを追加し、押すとホーム画面に飛ぶようにした。
## 動作確認

<!--
- どのような動作確認をしたのか？見つかった課題等はあるか？
-->
localhsot:3000で確認した。
## その他

<!--
- 伝えておくべき事や，補足資料などがあれば自由に記載して下さい
-->
ボタンの形など気になるところがあれば言ってください。