### PR TITLE
バッタのジャンプに溜めを作る

### DIFF
--- a/frontend/src/features/game/characters/enemy/constants.ts
+++ b/frontend/src/features/game/characters/enemy/constants.ts
@@ -44,7 +44,7 @@ export const RED_CATERPILLAR: EnemyEntity = {
 
 export const GRASSHOPPER: EnemyEntity = {
     name: "grasshopper-sprite",
-    velocityX: 80,
+    velocityX: 100,
     point: 150,
     frameWidth: 23,
     frameHeight: 12,

--- a/frontend/src/features/game/characters/enemy/index.ts
+++ b/frontend/src/features/game/characters/enemy/index.ts
@@ -116,7 +116,15 @@ export default class Enemy {
 
                 // Grasshopper の場合，地面衝突時にジャンプする
                 if (this.enemy === GRASSHOPPER && this.object?.body?.touching.down === true) {
-                    this.object?.setVelocityY(-500);
+                    this.object?.setVelocityX(0);
+
+                    const timer = Math.floor(Math.random() * 500);
+                    this.scene.time.delayedCall(timer, () => {
+                        if (this.object?.body?.velocity.x === 0) {
+                            this.object?.setVelocityY(-timer);
+                            this.object?.setVelocityX(GRASSHOPPER.velocityX);
+                        }
+                    });
                 }
             });
 


### PR DESCRIPTION
## 関連

- #51 

## 変更の概要

<!--
- 変更の概要を選択してください
- 複数選択可
 -->

-   [x] フロントエンド
-   [ ] バックエンド
-   [x] 機能関連
-   [ ] バグ修正
-   [ ] リファクタリング
-   [ ] ドキュメント
-   [ ] その他

## 変更の詳細

- バッタの定数としてジャンプ時のベロシティを追加
- ジャンプ時にランダム時間の溜めを作り、その値のベロシティをY軸方向に与える

## 動作確認

- バッタにランダムな時間の溜めがあることを確認
- バッタがランダムなジャンプ力であることを確認

## その他

なし