### PR TITLE
ゲーム開始と同時に画面を横向きに（モバイル）

### DIFF
--- a/frontend/src/components/Game/index.tsx
+++ b/frontend/src/components/Game/index.tsx
@@ -1,9 +1,21 @@
 import Phaser from "phaser"
 import React from "react";
 import { config } from "../../features/game/index";
- 
+import { is_set } from "../../utils/isType";
+
 export const GameComponent = () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const [game, setGame] = React.useState<Phaser.Game | null>(null);
+    const screenOrientation = window.screen.orientation;
+
+    // 画面を横向きに固定
+    if (is_set(screenOrientation)) {
+        // @ts-ignore
+        screenOrientation.lock('landscape')
+            .catch((error: unknown) => {
+                //
+            });
+    }
 
     React.useEffect(() => {
         const game = new Phaser.Game(config);
@@ -14,17 +26,17 @@ export const GameComponent = () => {
                 //
             }
         });
- 
+
         setGame(game);
- 
+
         return () => {
             game?.destroy(true)
         };
- 
+
     }, []);
- 
+
     return (
-        <div/>
+        <div />
     )
- 
+
 }

--- a/frontend/src/components/Game/index.tsx
+++ b/frontend/src/components/Game/index.tsx
@@ -9,9 +9,9 @@ export const GameComponent = () => {
     const screenOrientation = window.screen.orientation;
 
     // 画面を横向きに固定
-    if (is_set(screenOrientation)) {
+    if (is_set(screenOrientation) && (screenOrientation as any).lock) {
         // @ts-ignore
-        screenOrientation.lock('landscape')
+        (screenOrientation as any).lock('landscape')
             .catch((error: unknown) => {
                 //
             });

--- a/frontend/src/features/scores/api/store.ts
+++ b/frontend/src/features/scores/api/store.ts
@@ -1,5 +1,4 @@
 import { axios } from "../../../lib/axios";
-import Axios, {AxiosError, AxiosResponse} from "axios";
 
 /**
  * スコアを保存する
@@ -14,10 +13,10 @@ export const storeScoresApi = async (nickname: string, score: number): Promise<v
             nickname: nickname,
             score: score,
         })
-        .then((response: AxiosResponse) => {
-             //
+        .then(() => {
+            //
         })
-        .catch((error: AxiosError) => {
-            alert("スコアの保存に失敗しました")
+        .catch(() => {
+            //
         });
 };


### PR DESCRIPTION
## 関連

- #96 

## 変更の概要

<!--
- 変更の概要を選択してください
- 複数選択可
 -->

-   [x] フロントエンド
-   [ ] バックエンド
-   [x] 機能関連
-   [ ] バグ修正
-   [ ] リファクタリング
-   [ ] ドキュメント
-   [ ] その他

## 変更の詳細

- ゲーム開始時に画面を横向きに固定する（モバイル限定・PCは元から横向き判定）
- 画面の横向きが終了してしまうため、スコア保存時のエラーアラートを非表示に

## 動作確認

- ゲーム開始時にフルスクリーンかつ横画面となることを確認（PC・モバイル）

## その他

- 一応確認お願いします