### PR TITLE
時間内にゴールした際には残り秒数 * 5 の値をスコアに加算

### DIFF
--- a/frontend/src/features/game/characters/enemy/index.ts
+++ b/frontend/src/features/game/characters/enemy/index.ts
@@ -1,3 +1,4 @@
+import { GAME_OVER } from "../../constants/SceneKeys";
 import MainScene from "../../scenes/MainScene";
 import Character from "../Character";
 import Player from "../player";
@@ -165,7 +166,7 @@ export default class Enemy {
                     mainscene?.updateScore(this.enemy.point);
                 } else {
                     player.destroy(() => {
-                        mainscene?.startScene("GameOver");
+                        mainscene?.startScene(GAME_OVER);
                     }, 1000);
                 }
             });

--- a/frontend/src/features/game/constants/SceneKeys.ts
+++ b/frontend/src/features/game/constants/SceneKeys.ts
@@ -1,0 +1,3 @@
+export const GAME_CLEAR = "GameClear";
+export const GAME_OVER = "GameOver";
+export const TIME_OVER = "TimeOver";

--- a/frontend/src/features/game/scenes/GameClearScene.ts
+++ b/frontend/src/features/game/scenes/GameClearScene.ts
@@ -1,6 +1,7 @@
 import GameClearImage from "../components/images/GameClearImage";
 import TmpButton from "../components/buttons/TmpButton";
 import GameEndScene from "./GameEndScene";
+import { GAME_CLEAR } from "../constants/SceneKeys";
 
 /**
  * ゲームクリアシーン
@@ -10,7 +11,7 @@ export default class GameClearScene extends GameEndScene {
      * コンストラクタ
      */
     constructor() {
-        super("GameClear");
+        super(GAME_CLEAR);
 
         this.gameEndImage = new GameClearImage(this);
         this.tmpButton = new TmpButton(this);

--- a/frontend/src/features/game/scenes/GameOverScene.ts
+++ b/frontend/src/features/game/scenes/GameOverScene.ts
@@ -1,6 +1,7 @@
 import GameOverImage from "../components/images/GameOverImage";
 import TmpButton from "../components/buttons/TmpButton";
 import GameEndScene from "./GameEndScene";
+import { GAME_OVER } from "../constants/SceneKeys";
 
 /**
  * ゲームオーバーシーン
@@ -10,7 +11,7 @@ export default class GameOverScene extends GameEndScene {
      * コンストラクタ
      */
     constructor() {
-        super("GameOver");
+        super(GAME_OVER);
 
         this.gameEndImage = new GameOverImage(this);
         this.tmpButton = new TmpButton(this);

--- a/frontend/src/features/game/scenes/MainScene.ts
+++ b/frontend/src/features/game/scenes/MainScene.ts
@@ -5,6 +5,7 @@ import MoveLeftButton from "../components/buttons/move/MoveLeftButton";
 import MoveRightButton from "../components/buttons/move/MoveRightButton";
 import MainStage from "../stages/main";
 import Goal from "../characters/goal";
+import {GAME_CLEAR, GAME_OVER, TIME_OVER} from "../constants/SceneKeys";
 /**
  * ゲームのメインシーン
  */
@@ -201,7 +202,7 @@ export default class MainScene extends Phaser.Scene {
         // プレイヤー落下時にゲームオーバー画面に遷移する
         if (!this.physics.world.bounds.contains(this.cameras.main.width / 2, (this.player.object?.y as number) + 1)) {
             this.player.destroy(() => {
-                this.startScene("GameOver");
+                this.startScene(GAME_OVER);
             }, 1000);
         }
         this.player.callLimitVelocityX(-160, 160);
@@ -260,7 +261,7 @@ export default class MainScene extends Phaser.Scene {
         this.updateTimerDisplay();
 
         if (this.timeLimit <= 0) {
-            this.startScene("TimeOver");
+            this.startScene(TIME_OVER);
         }
     }
 
@@ -274,13 +275,19 @@ export default class MainScene extends Phaser.Scene {
      * @returns {void} 戻り値なし
      */
     startScene(key: String): void {
-        if(key==="GameOver" || key==="TimeOver"){
-            this.score*=0.8;
+        // ゲームオーバー・タイムオーバー時はスコアを減点
+        if (key === GAME_OVER || key === TIME_OVER) {
+            this.score *= 0.8;
         }
-        
-        const data = {
+
+        // ゲームクリア時は残り時間をスコアとして加算
+        if (key === GAME_CLEAR && this.timeLimit >= 0) {
+            this.score += this.timeLimit * 5;
+        }
+
+        // シーンを遷移する
+        this.scene.start(`${key}`, {
             score: this.score,
-        };
-        this.scene.start(`${key}`, data);
+        });
     }
 }

--- a/frontend/src/features/game/scenes/TimeOverScene.ts
+++ b/frontend/src/features/game/scenes/TimeOverScene.ts
@@ -1,13 +1,14 @@
 import TimeOverImage from "../components/images/TimeOverImage";
 import TmpButton from "../components/buttons/TmpButton";
 import GameEndScene from "./GameEndScene";
+import {TIME_OVER} from "../constants/SceneKeys";
 
 export default class TimeOverScene extends GameEndScene {
       /**
      * コンストラクタ
      */
       constructor() {
-        super("TimeOver");
+        super(TIME_OVER);
 
         this.gameEndImage = new TimeOverImage(this);
         this.tmpButton = new TmpButton(this);


### PR DESCRIPTION
## 関連

- #95 

## 変更の概要

<!--
- 変更の概要を選択してください
- 複数選択可
 -->

-   [x] フロントエンド
-   [ ] バックエンド
-   [x] 機能関連
-   [ ] バグ修正
-   [ ] リファクタリング
-   [ ] ドキュメント
-   [ ] その他

## 変更の詳細

- シーンの key を定数として利用する様に変更
- 時間内にゴールした際には残り時間 * 5 の値をスコアに加算

## 動作確認

- ゲームクリア時に残り時間 * 5 の値がスコアとして加算されていることを確認
- ゲームオーバー時に残り時間関連の値がスコアとして加算されていないことを確認
- タイムオーバー時に残り時間関連の値がスコアとして加算されていないことを確認

## その他

なし