### PR TITLE
スコア情報として保存する情報にプレイ難易度を追加

### DIFF
--- a/backend/src/controllers/api/scores.ts
+++ b/backend/src/controllers/api/scores.ts
@@ -7,6 +7,7 @@ import { nodeCache } from "../../lib/nodeCache";
 type scoresEntity = {
     nickname: string;
     score: number;
+    difficulty: number;
 };
 
 /**
@@ -33,14 +34,16 @@ export const getMethod = (mode?: string): Array<scoresEntity> | [] => {
  *
  * @param {string} nickname プレイヤー名
  * @param {number} score スコア
+ * @param {number} difficulty 難易度
  * @returns {void} 戻り値無し
  */
-export const postMethod = (nickname: string, score: number): void => {
+export const postMethod = (nickname: string, score: number, difficulty: number): void => {
     const scores: Array<scoresEntity> = nodeCache.get("scores") ?? [];
 
     scores.push({
         nickname: nickname,
         score: score,
+        difficulty: difficulty,
     });
 
     nodeCache.set("scores", scores);

--- a/backend/src/routes/api/scores.ts
+++ b/backend/src/routes/api/scores.ts
@@ -39,14 +39,15 @@ router.get("/scores", (req: Request, res: Response, next: NextFunction): void =>
 router.post("/scores", (req: Request, res: Response, next: NextFunction): void => {
     const nickname = req.body.nickname;
     const score = req.body.score;
+    const difficulty = req.body.difficulty;
 
     // リクエストボディのバリデーション
-    if (!is_string(nickname) || !is_number(score)) {
+    if (!is_string(nickname) || !is_number(score) || !is_number(difficulty)) {
         res.status(400).json({ message: "Bad request" });
         return;
     }
 
-    httpOk(res, { callback: () => postMethod(nickname, score) });
+    httpOk(res, { callback: () => postMethod(nickname, score, difficulty) });
 });
 
 export default router;

--- a/frontend/src/features/game/constants/DifficultyLevel.ts
+++ b/frontend/src/features/game/constants/DifficultyLevel.ts
@@ -1,0 +1,23 @@
+/**
+ * @property {number} SEED - 難易度のシード値
+ * @property {string} NAME - 難易度の名前
+ */
+export type DifficultyLevel = {
+    SEED: number;
+    NAME: string;
+};
+
+export const HARD: DifficultyLevel = {
+    SEED: 1,
+    NAME: "Hard",
+};
+export const NORMAL: DifficultyLevel = {
+    SEED: 2,
+    NAME: "Normal",
+};
+export const EASY: DifficultyLevel = {
+    SEED: 4,
+    NAME: "Easy",
+};
+
+export const DIFFICULTY_LEVELS: DifficultyLevel[] = [HARD, NORMAL, EASY];

--- a/frontend/src/features/game/constants/localStorageKeys.ts
+++ b/frontend/src/features/game/constants/localStorageKeys.ts
@@ -1,0 +1,5 @@
+// プレイヤーのニックネームを保存するためのキー
+export const NICKNAME = "nickname";
+
+// 難易度を保存するためのキー
+export const DIFFICULTY = "difficulty";

--- a/frontend/src/features/game/scenes/GameEndScene.ts
+++ b/frontend/src/features/game/scenes/GameEndScene.ts
@@ -4,6 +4,7 @@ import GameOverImage from "../components/images/GameOverImage";
 import GameClearImage from "../components/images/GameClearImage";
 import { storeScoresApi } from "../../scores/api";
 import TimeOverImage from "../components/images/TimeOverImage";
+import { is_set } from "../../../utils/isType";
 
 export default class GameEndScene extends Phaser.Scene {
     /**
@@ -69,6 +70,12 @@ export default class GameEndScene extends Phaser.Scene {
         const nickname = localStorage.getItem("nickname")?.length !== 0 ? localStorage.getItem("nickname") : null;
         localStorage.removeItem("nickname");
 
-        storeScoresApi(nickname ?? "名無し", this.score);
+        // プレイ難易度の取得
+        const difficulty = Number(localStorage.getItem("difficulty"));
+        if (!is_set<number>(difficulty)) {
+            return;
+        }
+
+        storeScoresApi(nickname ?? "名無し", this.score, difficulty);
     }
 }

--- a/frontend/src/features/game/scenes/GameEndScene.ts
+++ b/frontend/src/features/game/scenes/GameEndScene.ts
@@ -5,6 +5,7 @@ import GameClearImage from "../components/images/GameClearImage";
 import { storeScoresApi } from "../../scores/api";
 import TimeOverImage from "../components/images/TimeOverImage";
 import { is_set } from "../../../utils/isType";
+import { DIFFICULTY, NICKNAME } from "../constants/localStorageKeys";
 
 export default class GameEndScene extends Phaser.Scene {
     /**
@@ -67,11 +68,11 @@ export default class GameEndScene extends Phaser.Scene {
         });
         scoreText.setOrigin(0.5);
 
-        const nickname = localStorage.getItem("nickname")?.length !== 0 ? localStorage.getItem("nickname") : null;
-        localStorage.removeItem("nickname");
+        const nickname = localStorage.getItem(NICKNAME)?.length !== 0 ? localStorage.getItem(NICKNAME) : null;
+        localStorage.removeItem(NICKNAME);
 
         // プレイ難易度の取得
-        const difficulty = Number(localStorage.getItem("difficulty"));
+        const difficulty = Number(localStorage.getItem(DIFFICULTY));
         if (!is_set<number>(difficulty)) {
             return;
         }

--- a/frontend/src/features/game/scenes/MainScene.ts
+++ b/frontend/src/features/game/scenes/MainScene.ts
@@ -5,7 +5,8 @@ import MoveLeftButton from "../components/buttons/move/MoveLeftButton";
 import MoveRightButton from "../components/buttons/move/MoveRightButton";
 import MainStage from "../stages/main";
 import Goal from "../characters/goal";
-import {GAME_CLEAR, GAME_OVER, TIME_OVER} from "../constants/SceneKeys";
+import { GAME_CLEAR, GAME_OVER, TIME_OVER } from "../constants/SceneKeys";
+import { DIFFICULTY } from "../constants/localStorageKeys";
 /**
  * ゲームのメインシーン
  */
@@ -93,7 +94,7 @@ export default class MainScene extends Phaser.Scene {
 
         this.events.on("update", this.updateTimer, this);
 
-        this.difficult = Number(localStorage.getItem("difficult"));
+        this.difficult = Number(localStorage.getItem(DIFFICULTY));
     }
 
     /**

--- a/frontend/src/features/scores/api/read.ts
+++ b/frontend/src/features/scores/api/read.ts
@@ -1,6 +1,6 @@
 import { axios } from "../../../lib/axios";
-import {ScoreEntity} from "../../../types";
-import {AxiosError, AxiosResponse} from "axios";
+import { ScoreEntity } from "../../../types";
+import { AxiosError, AxiosResponse } from "axios";
 
 /**
  * スコアを取得する
@@ -14,9 +14,11 @@ export const getScoresApi = async (mode?: string): Promise<ScoreEntity[] | []> =
             params: {
                 mode: mode,
             },
-        }).then((response: AxiosResponse<{data: ScoreEntity[]}>) => {
+        })
+        .then((response: AxiosResponse<{ data: ScoreEntity[] }>) => {
             return response.data.data;
-        }).catch((error: AxiosError) => {
+        })
+        .catch((error: AxiosError) => {
             return [];
         });
 };

--- a/frontend/src/features/scores/api/store.ts
+++ b/frontend/src/features/scores/api/store.ts
@@ -1,23 +1,25 @@
 import { axios } from "../../../lib/axios";
-import Axios, {AxiosError, AxiosResponse} from "axios";
+import Axios, { AxiosError, AxiosResponse } from "axios";
 
 /**
  * スコアを保存する
  *
  * @param {string} nickname ニックネーム
  * @param {number} score スコア
+ * @param {number} difficulty 難易度
  * @returns {Promise<void>} 戻り値無し
  */
-export const storeScoresApi = async (nickname: string, score: number): Promise<void> => {
+export const storeScoresApi = async (nickname: string, score: number, difficulty: number): Promise<void> => {
     return await axios
         .post("/api/scores", {
             nickname: nickname,
             score: score,
+            difficulty: difficulty,
         })
         .then((response: AxiosResponse) => {
-             //
+            //
         })
         .catch((error: AxiosError) => {
-            alert("スコアの保存に失敗しました")
+            alert("スコアの保存に失敗しました");
         });
 };

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -17,6 +17,7 @@ import { GameComponent } from "../components/Game";
 import Select from '@mui/material/Select';
 import { SelectChangeEvent } from '@mui/material/Select/SelectInput';
 import { DIFFICULTY_LEVELS, DifficultyLevel } from "../features/game/constants/DifficultyLevel";
+import { DIFFICULTY, NICKNAME } from "../features/game/constants/localStorageKeys";
 
 const style = {
     position: 'absolute' as 'absolute',
@@ -83,8 +84,8 @@ export const Home = () => {
             }
         }
 
-        localStorage.setItem("nickname", nickname);
-        localStorage.setItem("difficulty", String(difficult));
+        localStorage.setItem(NICKNAME, nickname);
+        localStorage.setItem(DIFFICULTY, String(difficult));
         setIsFullScreen(!isFullScreen);
     }
 

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -16,6 +16,7 @@ import '../index.css';
 import { GameComponent } from "../components/Game";
 import Select from '@mui/material/Select';
 import { SelectChangeEvent } from '@mui/material/Select/SelectInput';
+import { DIFFICULTY_LEVELS, DifficultyLevel } from "../features/game/constants/DifficultyLevel";
 
 const style = {
     position: 'absolute' as 'absolute',
@@ -83,8 +84,8 @@ export const Home = () => {
         }
 
         localStorage.setItem("nickname", nickname);
+        localStorage.setItem("difficulty", String(difficult));
         setIsFullScreen(!isFullScreen);
-        localStorage.setItem("difficult", String(difficult));
     }
 
     const HomeComponent = () => (
@@ -103,9 +104,9 @@ export const Home = () => {
                     <FormControl sx={{ marginY: 2, background: "#ffffff", width: 100, marginRight: '10px', borderRadius: "5px" }}>
                         <InputLabel id="a-label">難易度</InputLabel>
                         <Select labelId="a-label" id="a" onChange={handleChange} value={difficult} label="Age">
-                            <MenuItem value={1}>Hard</MenuItem>
-                            <MenuItem value={2}>Normal</MenuItem>
-                            <MenuItem value={4}>Easy</MenuItem>
+                            {DIFFICULTY_LEVELS.map((LEVEL: DifficultyLevel) => {
+                                return <MenuItem value={LEVEL.SEED}>{LEVEL.NAME}</MenuItem>
+                            })}
                         </Select>
                     </FormControl>
                     <Button variant="contained" sx={{ marginY: 2, marginX: 1 }} onClick={() => handleGameStart(difficult)}>Game Start</Button>

--- a/frontend/src/pages/Scores.tsx
+++ b/frontend/src/pages/Scores.tsx
@@ -80,14 +80,14 @@ export default function Scores(): JSX.Element {
             textColor = 'white'; // 4位と5位の文字色
         }
 
-            return (
-                <Typography key={index} className="mfont" align="center" sx={{ color: textColor, fontFamily: 'fantasy', fontSize: fontSize }}>
-                    <div>{`NO.${index + 1} ${score.nickname}`}</div>
-                    <div>{`${score.score}p`}</div>
-                    <br />
-                </Typography>
-            );
-        });
+        return (
+            <Typography key={index} className="mfont" align="center" sx={{ color: textColor, fontFamily: 'fantasy', fontSize: fontSize }}>
+                <div>{`NO.${index + 1} ${score.nickname}`}</div>
+                <div>{`${score.score}p`}</div>
+                <br />
+            </Typography>
+        );
+    });
 
     // すべてのスコアを表示
     const allScores = scores.map((score: ScoreEntity, index: number) => {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -7,4 +7,5 @@
 export type ScoreEntity = {
     nickname: string;
     score: number;
-}
+    difficulty: number;
+};


### PR DESCRIPTION
## 関連

- #100 

## 変更の概要

<!--
- 変更の概要を選択してください
- 複数選択可
 -->

-   [x] フロントエンド
-   [x] バックエンド
-   [x] 機能関連
-   [ ] バグ修正
-   [x] リファクタリング
-   [ ] ドキュメント
-   [ ] その他

## 変更の詳細

- 難易度関連の定数を定数ファイルとして作成
- フロントエンドのスコア保存APIで難易度情報をデータとして渡すよう修正
- バックエンドのスコア保存で難易度情報がリクエストボディに含まれているかを確認

## 動作確認

- ゲームプレイ時の難易度情報が、スコア表示ページで取得できることを確認

## その他

なし