### PR TITLE
feat: 難易度ごとに出現させるエネミーを限定する #99

### DIFF
--- a/frontend/src/features/game/characters/enemy/index.ts
+++ b/frontend/src/features/game/characters/enemy/index.ts
@@ -2,7 +2,16 @@ import { GAME_OVER } from "../../constants/SceneKeys";
 import MainScene from "../../scenes/MainScene";
 import Character from "../Character";
 import Player from "../player";
-import { BASE_CATERPILLAR, ERROR_CATERPILLAR, RED_CATERPILLAR, GRASSHOPPER, ENEMY_CONFIGS } from "./constants";
+import {
+    BASE_CATERPILLAR,
+    ERROR_CATERPILLAR,
+    RED_CATERPILLAR,
+    GRASSHOPPER,
+    ENEMY_CONFIGS,
+    EnemyEntity,
+} from "../../constants/Enemies";
+import { DIFFICULTY_LEVEL_MAP } from "../../constants/DifficultyLevel";
+import { getAryRand } from "../../../../utils/Random";
 
 /**
  * エネミーの種類
@@ -84,10 +93,12 @@ export default class Enemy {
     }
     /**
      * 敵の名前をランダムに取得する
+     *
+     * @param {number} difficult 難易度
      * @returns {EnemyName} 敵の名前
      */
-    static get_enemyName(): EnemyName {
-        return ENEMY_CONFIGS[Phaser.Math.Between(0, 3)];
+    static get_enemyName(difficult: number): EnemyName {
+        return getAryRand<EnemyEntity>(DIFFICULTY_LEVEL_MAP[difficult].enemies);
     }
 
     /**

--- a/frontend/src/features/game/constants/DifficultyLevel.ts
+++ b/frontend/src/features/game/constants/DifficultyLevel.ts
@@ -1,0 +1,37 @@
+import { BASE_CATERPILLAR, ERROR_CATERPILLAR, EnemyEntity, GRASSHOPPER, RED_CATERPILLAR } from "./Enemies";
+
+/**
+ * 難易度レベル
+ *
+ * @property {number} SEED シード値
+ * @property {string} NAME 難易度名
+ * @property {EnemyEntity[]} enemies 出現する敵の配列
+ */
+export type DifficultyLevel = {
+    SEED: number;
+    NAME: string;
+    enemies: EnemyEntity[];
+};
+
+export const HARD: DifficultyLevel = {
+    SEED: 1,
+    NAME: "Hard",
+    enemies: [BASE_CATERPILLAR, RED_CATERPILLAR, ERROR_CATERPILLAR, GRASSHOPPER],
+};
+export const NORMAL: DifficultyLevel = {
+    SEED: 2,
+    NAME: "Normal",
+    enemies: [BASE_CATERPILLAR, RED_CATERPILLAR, ERROR_CATERPILLAR],
+};
+export const EASY: DifficultyLevel = {
+    SEED: 4,
+    NAME: "Easy",
+    enemies: [BASE_CATERPILLAR, RED_CATERPILLAR],
+};
+
+// シード値をキーにした難易度レベルのマップ
+export const DIFFICULTY_LEVEL_MAP: { [key: string]: DifficultyLevel } = {
+    [HARD.SEED]: HARD,
+    [NORMAL.SEED]: NORMAL,
+    [EASY.SEED]: EASY,
+};

--- a/frontend/src/features/game/constants/Enemies.ts
+++ b/frontend/src/features/game/constants/Enemies.ts
@@ -1,4 +1,6 @@
 /**
+ * 敵の種類
+ *
  * @property {string} name 名前
  * @property {number} velocityX 速度
  * @property {number} point 倒した時のポイント
@@ -6,7 +8,7 @@
  * @property {number} frameHeight 画像の縦幅
  * @property {number} frameRate アニメーションのフレームレート
  */
-type EnemyEntity = {
+export type EnemyEntity = {
     name: string;
     velocityX: number;
     point: number;
@@ -24,15 +26,6 @@ export const BASE_CATERPILLAR: EnemyEntity = {
     frameRate: 1,
 };
 
-export const ERROR_CATERPILLAR: EnemyEntity = {
-    name: "error-caterpillar-sprite",
-    velocityX: 80,
-    point: 130,
-    frameWidth: 30,
-    frameHeight: 8,
-    frameRate: 8,
-};
-
 export const RED_CATERPILLAR: EnemyEntity = {
     name: "red-caterpillar-sprite",
     velocityX: 100,
@@ -40,6 +33,15 @@ export const RED_CATERPILLAR: EnemyEntity = {
     frameWidth: 30,
     frameHeight: 8,
     frameRate: 10,
+};
+
+export const ERROR_CATERPILLAR: EnemyEntity = {
+    name: "error-caterpillar-sprite",
+    velocityX: 80,
+    point: 130,
+    frameWidth: 30,
+    frameHeight: 8,
+    frameRate: 8,
 };
 
 export const GRASSHOPPER: EnemyEntity = {
@@ -51,4 +53,9 @@ export const GRASSHOPPER: EnemyEntity = {
     frameRate: 2,
 };
 
-export const ENEMY_CONFIGS = [BASE_CATERPILLAR, ERROR_CATERPILLAR, RED_CATERPILLAR, GRASSHOPPER];
+export const ENEMY_CONFIGS = [
+    /* 0 => */ BASE_CATERPILLAR,
+    /* 1 => */ RED_CATERPILLAR,
+    /* 2 => */ ERROR_CATERPILLAR,
+    /* 3 => */ GRASSHOPPER,
+];

--- a/frontend/src/features/game/scenes/MainScene.ts
+++ b/frontend/src/features/game/scenes/MainScene.ts
@@ -5,7 +5,7 @@ import MoveLeftButton from "../components/buttons/move/MoveLeftButton";
 import MoveRightButton from "../components/buttons/move/MoveRightButton";
 import MainStage from "../stages/main";
 import Goal from "../characters/goal";
-import {GAME_CLEAR, GAME_OVER, TIME_OVER} from "../constants/SceneKeys";
+import { GAME_CLEAR, GAME_OVER, TIME_OVER } from "../constants/SceneKeys";
 /**
  * ゲームのメインシーン
  */
@@ -180,7 +180,7 @@ export default class MainScene extends Phaser.Scene {
 
         // 初期画面に敵を配置
         for (let i = 0; i < 6 / this.difficult; i++) {
-            const newEnemy = new Enemy(this, Enemy.get_enemyName());
+            const newEnemy = new Enemy(this, Enemy.get_enemyName(this.difficult));
             newEnemy.create(
                 [this.stage.ground.platform.object] as Phaser.Physics.Arcade.StaticGroup[],
                 this.player,
@@ -221,7 +221,7 @@ export default class MainScene extends Phaser.Scene {
 
         let rand = Phaser.Math.Between(0, 70 * this.difficult);
 
-        let enemy_name = Enemy.get_enemyName();
+        let enemy_name = Enemy.get_enemyName(this.difficult);
         if (this.before_x === undefined) {
             this.before_x = this.cameras.main.scrollX;
         }

--- a/frontend/src/utils/Random.ts
+++ b/frontend/src/utils/Random.ts
@@ -1,0 +1,9 @@
+/**
+ * 配列の中身をランダムに取り出す
+ *
+ * @param {Array<T>} array - ランダムに中身を取り出したい配列
+ * @returns {T} ランダムに取り出した配列の中身
+ */
+export function getAryRand<T>(array: T[]): T {
+    return array[Math.floor(Math.random() * array.length)];
+}


### PR DESCRIPTION
## 関連

- #99 

## 変更の概要

<!--
- 変更の概要を選択してください
- 複数選択可
 -->

-   [x] フロントエンド
-   [ ] バックエンド
-   [x] 機能関連
-   [ ] バグ修正
-   [x] リファクタリング
-   [ ] ドキュメント
-   [ ] その他

## 変更の詳細

- エネミー情報の定数ファイルを移動
- ゲームの難易度関連の定数ファイルを作成
- 配列の中身をランダムに取り出す関数の作成
- 難易度ごとに出現させるエネミーを、エネミー情報の定数を用いて指定できるように変更

## 動作確認

- すべての難易度で、 https://github.com/Obanyan2023/susumukun/issues/99#issue-1955332011 に従ったエネミーのみ出現していることを確認

## その他

なし