### PR TITLE
スコア保存失敗時のゲームオーバー関連シーンが横向きとなるように修正

### DIFF
--- a/frontend/src/features/scores/api/store.ts
+++ b/frontend/src/features/scores/api/store.ts
@@ -1,5 +1,4 @@
 import { axios } from "../../../lib/axios";
-import Axios, { AxiosError, AxiosResponse } from "axios";
 
 /**
  * スコアを保存する
@@ -16,10 +15,10 @@ export const storeScoresApi = async (nickname: string, score: number, difficulty
             score: score,
             difficulty: difficulty,
         })
-        .then((response: AxiosResponse) => {
+        .then(() => {
             //
         })
-        .catch((error: AxiosError) => {
-            alert("スコアの保存に失敗しました");
+        .catch(() => {
+            //
         });
 };


### PR DESCRIPTION
## 関連

- #96 

## 変更の概要

<!--
- 変更の概要を選択してください
- 複数選択可
 -->

-   [x] フロントエンド
-   [ ] バックエンド
-   [ ] 機能関連
-   [x] バグ修正
-   [ ] リファクタリング
-   [ ] ドキュメント
-   [ ] その他

## 変更の詳細

- スコア保存失敗時にゲームクリアやゲームオーバー画面などでも横向き画面となるように修正

## 動作確認

- スコア保存失敗時のゲームクリア画面等でも横向き画面となることを確認

## その他

なし