### PR TITLE
ワールド上下の上限値を増加・プレイヤーが画面上部にいる場合はカメラを上に移動させる

### DIFF
--- a/frontend/src/features/game/characters/player/index.ts
+++ b/frontend/src/features/game/characters/player/index.ts
@@ -1,3 +1,4 @@
+import { is_set } from "../../../../utils/isType";
 import Character from "../Character";
 import LeftAnimation from "./animations/LeftAnimation";
 import RightAnimation from "./animations/RightAnimation";
@@ -81,7 +82,7 @@ export default class Player {
      */
     create(objects?: Phaser.Physics.Arcade.StaticGroup[]): void {
         // プレイヤーとそのアニメーションの宣言
-        this.object = new Character(this.scene, window.innerWidth / 4, window.innerHeight/4, "susumu");
+        this.object = new Character(this.scene, window.innerWidth / 4, window.innerHeight / 2, "susumu");
         this.object.setOrigin(0.5, 1);
         this.cursors = this.scene.input.keyboard?.createCursorKeys();
         this.animation = {
@@ -98,8 +99,8 @@ export default class Player {
         // 初めに正面を向かせるために1度呼び出し
         this.animation.turn.update();
 
-        // カメラの追従
-        this.scene.cameras.main.startFollow(this.object);
+        // カメラの追従・Y軸の固定
+        this.scene.cameras.main.startFollow(this.object, false, 1, 0);
 
         // 衝突するオブジェクトの設定
         // 壁に衝突したら加速度と反対向きに減速
@@ -118,32 +119,31 @@ export default class Player {
             if (this.object?.body?.touching.down) {
                 this.object?.setVelocityY(-400);
             }
-        })
+        });
 
         this.cursors?.left?.on("up", () => {
             this.animation?.turn.update();
             this.object?.setAccelerationX(0);
             this.object?.setVelocityX(0);
-        })
+        });
 
         this.cursors?.right?.on("up", () => {
             this.animation?.turn.update();
             this.object?.setAccelerationX(0);
             this.object?.setVelocityX(0);
-        })
+        });
 
         this.cursors?.left?.on("down", () => {
             this.animation?.left.update();
             this.object?.setAccelerationX(-300);
             this.object?.setVelocityX(-160);
-        })
+        });
 
         this.cursors?.right?.on("down", () => {
             this.animation?.right.update();
             this.object?.setAccelerationX(300);
             this.object?.setVelocityX(160);
-        })
-
+        });
     }
     /**
      * x方向の速度の上限・下限値を設定する
@@ -157,25 +157,44 @@ export default class Player {
         }
     }
 
+    /**
+     * プレイヤーの更新
+     *
+     * @returns {void} 戻り値なし
+     */
     update(): void {
+        if (!is_set<Character>(this.object) || !is_set<Object>(this.object.body)) {
+            return;
+        }
+
+        // プレイヤーが画面の上側（3割以上）に来たらカメラを上（上限50）に移動させる
+        if (this.object.body.y < this.scene.scale.height * 0.3 && this.scene.cameras.main.scrollY > -50) {
+            this.scene.cameras.main.setScroll(this.scene.cameras.main.scrollX, this.scene.cameras.main.scrollY - 1);
+        }
+
+        // プレイヤーが画面の下側（5割以下）に来たらカメラを下（下限0・中央まで）に移動させる
+        if (this.scene.scale.height * 0.5 < this.object.body.y && this.scene.cameras.main.scrollY < 0) {
+            if (this.object.body.y !== this.scene.cameras.main.scrollY) {
+                this.scene.cameras.main.setScroll(this.scene.cameras.main.scrollX, this.scene.cameras.main.scrollY + 5);
+            } else {
+                this.scene.cameras.main.setScroll(this.scene.cameras.main.scrollX, this.object.body.y + 1);
+            }
+        }
     }
 
     /**
-    * 削除処理
-    * 
-    * @param {()=>void} callback 削除時のコールバック関数
-    * @param {number} timeout コールバック関数が呼び出されるまでの待機時間
-    * @returns {void} 戻り値なし
-    * @description プレイヤーを非表示にし、待機時間後にコールバック関数を呼び出す。
-    */
+     * 削除処理
+     *
+     * @param {()=>void} callback 削除時のコールバック関数
+     * @param {number} timeout コールバック関数が呼び出されるまでの待機時間
+     * @returns {void} 戻り値なし
+     * @description プレイヤーを非表示にし、待機時間後にコールバック関数を呼び出す。
+     */
     destroy(callback: () => void, timeout: number): void {
         this.object?.setVisible(false);
         this.scene.cameras.main.stopFollow();
-        this.scene.time.delayedCall(
-            timeout,
-            () => {
-                callback();
-            }
-        )
+        this.scene.time.delayedCall(timeout, () => {
+            callback();
+        });
     }
 }

--- a/frontend/src/features/game/scenes/MainScene.ts
+++ b/frontend/src/features/game/scenes/MainScene.ts
@@ -7,7 +7,7 @@ import MainStage from "../stages/main";
 import Goal from "../characters/goal";
 import { GAME_CLEAR, GAME_OVER, TIME_OVER } from "../constants/SceneKeys";
 import { DIFFICULTY } from "../constants/localStorageKeys";
-/**
+/*
  * ゲームのメインシーン
  */
 export default class MainScene extends Phaser.Scene {
@@ -141,11 +141,19 @@ export default class MainScene extends Phaser.Scene {
         this.scoreText = this.add.text(10, 10, `Score: ${this.score}`, { fontSize: "40px" });
         this.scoreText.setScrollFactor(0);
 
+        /**
+         * ステージの設定
+         *
+         * @property {number} stage_x - ステージのX座標
+         * @property {number} stage_y - ステージのY座標 (画面を超えてジャンプできる様に -100)
+         * @property {number} width - ステージの幅
+         * @property {number} height - ステージの高さ（stage_y の負の値・カメラ位置調整）
+         */
         const stage = {
             stage_x: 0,
-            stage_y: 0,
+            stage_y: -200,
             width: 6900,
-            height: window.innerHeight,
+            height: window.innerHeight + 200,
         };
 
         // カメラの設定
@@ -154,7 +162,6 @@ export default class MainScene extends Phaser.Scene {
         // ワールドの境界を設定する
         this.physics.world.setBounds(stage.stage_x, stage.stage_y, stage.width, stage.height);
 
-        this.cameras.main.setBounds(stage.stage_x, stage.stage_y, stage.width, stage.height);
         this.cameras.main.setScroll(0, 0); // カメラのスクロールを0に設定
 
         this.timeObject = this.add.text(


### PR DESCRIPTION
## 関連

- #102 

## 変更の概要

<!--
- 変更の概要を選択してください
- 複数選択可
 -->

-   [x] フロントエンド
-   [ ] バックエンド
-   [x] 機能関連
-   [x] バグ修正
-   [ ] リファクタリング
-   [ ] ドキュメント
-   [ ] その他

## 変更の詳細

- ワールド上下の上限を増加
- プレイヤーが画面の上側（3割以上）に来たらカメラを上（上限50）に移動させる
- プレイヤーが画面の下側（5割以下）に来たらカメラを下（下限0・中央まで）に移動させる

## 動作確認

- プレイヤーが背景画像以上の高さまで移動できることを確認
- プレイヤーが画面上部に移動するとカメラが上に移動することを確認（上限値あり）
- プレイヤーが画面下部に移動するとカメラが下に移動することを確認（下限値あり）

## その他

- ステージ最後の飛び降り時に下側の地面が見えません