### PR TITLE
スコアページを難易度ごとの表示にする

### DIFF
--- a/frontend/src/pages/Scores.tsx
+++ b/frontend/src/pages/Scores.tsx
@@ -12,6 +12,7 @@ import { is_set } from "../utils/isType";
 import { getScoresApi, storeScoresApi } from "../features/scores/api";
 import '../index.css';
 import Background from '../assets/images/black.png';
+import {DIFFICULTY_LEVELS, DifficultyLevel, EASY, HARD, NORMAL} from "../features/game/constants/DifficultyLevel";
 
 /**
  * スコア画面
@@ -19,22 +20,8 @@ import Background from '../assets/images/black.png';
  * @return {JSX.Element}
  */
 export default function Scores(): JSX.Element {
-    const [scores, setScores] = useState<ScoreEntity[]>([]);
+    const [scores, setScores] = useState<{[key: number] : ScoreEntity[]}>([]);
     const [open, setOpen] = React.useState(false);
-
-    // 背景画像のスタイル
-    const style = {
-        position: 'absolute' as 'absolute',
-        top: '50%',
-        left: '50%',
-        transform: 'translate(-50%, -50%)',
-        width: 400,
-        bgcolor: 'background.paper',
-        border: '2px solid #000',
-        boxShadow: 24,
-        p: 4,
-        borderRadius: '16px',
-    };
 
     // ウィンドウサイズを設定
     const setWinSize = () => {
@@ -58,75 +45,39 @@ export default function Scores(): JSX.Element {
     // スコアを取得
     useEffect(() => {
         getScoresApi(DESC).then((res: ScoreEntity[]) => {
-            setScores(res);
+            const hardScores: ScoreEntity[] = res.filter((v: ScoreEntity): boolean => v.difficulty === HARD.SEED);
+            const normalScores: ScoreEntity[] = res.filter((v: ScoreEntity): boolean => v.difficulty === NORMAL.SEED);
+            const easyScores: ScoreEntity[] = res.filter((v: ScoreEntity): boolean => {
+                return v.difficulty === EASY.SEED;
+            });
+
+            setScores({
+                [HARD.SEED]: hardScores ?? [],
+                [NORMAL.SEED]: normalScores ?? [],
+                [EASY.SEED]: easyScores ?? [],
+            });
         });
     }, []);
 
-    // TOP 5 スコアを表示
-    const topFiveScores = scores.slice(0, 5).map((score: ScoreEntity, index: number) => {
-        let fontSize;
-        let textColor;
-        if (index === 0) {
-            fontSize = 40; // 1位の文字サイズ
-            textColor = "#FFD700"; // 1位の文字色
-        } else if (index === 1) {
-            fontSize = 30; // 2位の文字サイズ
-            textColor = "#C0C0C0"; // 2位の文字色
-        } else if (index === 2) {
-            fontSize = 25; // 3位の文字サイズ
-            textColor = "#cda16f"; // 3位の文字色
-        } else {
-            fontSize = 20; // 4位と5位の文字サイズ
-            textColor = 'white'; // 4位と5位の文字色
-        }
-
-        return (
-            <Typography key={index} className="mfont" align="center" sx={{ color: textColor, fontFamily: 'fantasy', fontSize: fontSize }}>
-                <div>{`NO.${index + 1} ${score.nickname}`}</div>
-                <div>{`${score.score}p`}</div>
-                <br />
-            </Typography>
-        );
-    });
-
-    // すべてのスコアを表示
-    const allScores = scores.map((score: ScoreEntity, index: number) => {
-        return (
-            <Typography key={index} className="mfont" align="center" sx={{ color: 'white', fontFamily: 'fantasy', fontSize: 20 }}>
-                <div>{`${index + 1}. ${score.nickname}`}</div>
-                <div>{`${score.score}p`}</div>
-                <br />
-            </Typography>
-        );
-    });
-
     return (
         <MainLayout title={"走れ！すすむ君！ - スコア"}>
-            <Box sx={image}>
-                <Grid container alignItems={"center"} direction={"column"} sx={{ overflow: 'hidden', height: '100vh', width: '100vw' }}>
-                    <div>
-                        <div style={{ float: 'left', width: '50%' }}>
-                            <Typography className="mfont" align="center" sx={{ color: 'red', fontFamily: 'fantasy', fontSize: 40 }}>
-                                TOP 5
-                            </Typography>
-                            {is_set<ScoreEntity[]>(scores) && (
-                                <div style={{ overflow: 'auto', maxWidth: '1000px', maxHeight: '500px', textAlign: 'center', overflowY: 'scroll' }}>
-                                    {topFiveScores}
-                                </div>
-                            )}
-                        </div>
-                        <div style={{ float: 'left', width: '50%' }}>
-                            <Typography className="mfont" align="center" sx={{ color: 'gray', fontFamily: 'fantasy', fontSize: 40 }}>
-                                ALL RANKING
-                            </Typography>
-                            {is_set<ScoreEntity[]>(scores) && (
-                                <div style={{ overflow: 'auto', maxHeight: '500px', textAlign: 'center', overflowY: 'scroll' }}>
-                                    {allScores}
-                                </div>
-                            )}
-                        </div>
-                    </div>
-                    <div><Button href="/" variant="contained" color='inherit' sx={{ margin: 3 }}> 閉じる</Button></div>
+            <Box sx={{...image, height: '100%', width: '100%'}}>
+                <Grid>
+                    <Button href="/" variant="contained" color='inherit' sx={{ margin: 3 }}> 閉じる</Button>
+                </Grid>
+                <Grid container alignItems={"flex-start"} justifyContent={"space-evenly"} direction={"row"}>
+                        {is_set<{[key: number]: ScoreEntity[]}>(scores) && DIFFICULTY_LEVELS.map((v: DifficultyLevel): React.JSX.Element => (
+                            <Box sx={{ margin: 3}}>
+                                <Typography className="mfont" align="center" sx={{ color: 'red', fontFamily: 'fantasy', fontSize: 40 }}>
+                                    {v.NAME}
+                                </Typography>
+                                {is_set<ScoreEntity[]>(scores[v.SEED]) && scores[v.SEED].map((v: ScoreEntity, i: number) =>  (
+                                    <Typography key={i} className="mfont" align="center" sx={{ color: 'gray', fontFamily: 'fantasy', fontSize: 30, marginTop: 1, marginBottom: 1 }}>
+                                        {i + 1}位 {v.nickname} {v.score}
+                                    </Typography>
+                                ))}
+                            </Box>
+                        ))}
                 </Grid>
             </Box>
         </MainLayout>


### PR DESCRIPTION
## 関連

- #101 

## 変更の概要

<!--
- 変更の概要を選択してください
- 複数選択可
 -->

-   [x] フロントエンド
-   [ ] バックエンド
-   [x] 機能関連
-   [ ] バグ修正
-   [ ] リファクタリング
-   [ ] ドキュメント
-   [ ] その他

## 変更の詳細

- スコアページの表示を難易度ごとにする

## 動作確認

- 難易度ごとにスコアが表示されていることを確認

## その他

なし