### PR TITLE
ステージ右側やステージ上部にカメラが移動した際の黒い部分を背景画像にする

### DIFF
--- a/frontend/src/features/game/stages/main/background/Sky.ts
+++ b/frontend/src/features/game/stages/main/background/Sky.ts
@@ -15,7 +15,7 @@ export default class Sky extends BaseBackground {
      * @returns {void} 戻り値なし
      */
     preload(): void {
-        this.scene.load.image("parkingarea", "images/background/ground.png")
+        this.scene.load.image("parkingarea", "images/background/ground.png");
     }
 
     /**
@@ -24,10 +24,14 @@ export default class Sky extends BaseBackground {
      * @returns {void} 戻り値なし
      */
     create(): void {
-        this.image = this.scene.add.image(0, window.innerHeight/2,"parkingarea").setScrollFactor(0.5);
-        const scaleY = window.innerHeight / this.image.height;
-        const scaleX = scaleY;
-        this.image.setScale(scaleX, scaleY);
-        this.image.setOrigin(0 ,0.5);
+        this.image = this.scene.add.image(0, window.innerHeight / 2, "parkingarea").setScrollFactor(0.5);
+        const maxSize = Math.min(window.innerWidth, window.innerHeight);
+        const imageMarginHeight = Math.max(50000 / maxSize, 1);
+        const imageHeight = this.image.height - imageMarginHeight;
+        const scale = window.innerHeight / imageHeight;
+
+        this.image.setScale(scale, scale);
+        this.image.setOrigin(0, 0.5);
+        this.image.setPosition(0, window.innerHeight / 2 - imageMarginHeight / 3);
     }
 }


### PR DESCRIPTION
## 関連

- #119 

## 変更の概要

<!--
- 変更の概要を選択してください
- 複数選択可
 -->

-   [x] フロントエンド
-   [ ] バックエンド
-   [x] 機能関連
-   [ ] バグ修正
-   [ ] リファクタリング
-   [ ] ドキュメント
-   [ ] その他

## 変更の詳細

- ステージ右側やステージ上部にカメラが移動した際の黒い部分を背景画像にする
- 画面サイズが小さい程画面上下に余白を作り，カメラ移動時に黒い部分が見えないようにする

## 動作確認

- ディベロッパーツールで iPhone SE などの画面サイズが小さいデバイスでもカメラ移動時に黒い部分が出ないことを確認
- PC画面でカメラ移動時に黒い部分が出ないことを確認

## その他

なし