### PR TITLE
welcomeページの背景画像が画面全体に表示されるように修正した

### DIFF
--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -46,7 +46,7 @@ const image = {
     backgroundImage: `url(${setWinSize()})`,
     backgroundSize: 'cover',
     backgroundRepeat: 'no-repeat',  // 画像の繰り返しを無効にする
-    backgroundPosition: 'center'
+    backgroundPosition: 'center',
 };
 
 const closebutton = {
@@ -91,7 +91,7 @@ export const Home = () => {
 
     const HomeComponent = () => (
         <Box sx={image}>
-            <Box sx={{ height: '100vh', width: '100vw', justifyContent: "space-between" }}>
+            <Box sx={{ minHeight: '100vh', minWidth: '100vw', justifyContent: "space-between" }}>
                 <Typography className="mfont" align="center" variant="h3" sx={{ fontFamily: 'Mochiy Pop P One', paddingY: 7 }}>
                     走れ！すすむ君！
                 </Typography>
@@ -99,7 +99,7 @@ export const Home = () => {
                     <Grid item xs={12} sx={{ paddingBottom: 3 }}>
                         <TextField focused label="ニックネーム" variant="filled" value={nickname} onChange={(e) => setNickname(e.target.value)} sx={{ bgcolor: "white" }} />
                     </Grid>
-                    <Grid item xs={12} sx={{ paddingBottom: 3 }}>
+                    <Grid item xs={12} sx={{ paddingBottom: 3}}>
                         <FormControl>
                             <InputLabel id="a-label">難易度</InputLabel>
                             <Select labelId="a-label" id="a" sx={{ bgcolor: "white" }} onChange={handleChange} value={difficult} label="Age">

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -46,7 +46,7 @@ const image = {
     backgroundImage: `url(${setWinSize()})`,
     backgroundSize: 'cover',
     backgroundRepeat: 'no-repeat',  // 画像の繰り返しを無効にする
-    backgroundPosition: 'center',
+    backgroundPosition: 'center'
 };
 
 const closebutton = {


### PR DESCRIPTION
## 関連

<!--
- 関連するPull request, Issueなど
-->
https://github.com/Obanyan2023/susumukun/issues/123

## 変更の概要

<!--
- 変更の概要を選択してください
- 複数選択可
 -->

-   [x] フロントエンド
-   [ ] バックエンド
-   [ ] 機能関連
-   [x] バグ修正
-   [ ] リファクタリング
-   [ ] ドキュメント
-   [ ] その他

## 変更の詳細

<!--
- 変更の詳細をなるべく具体的に記載して下さい
 -->
- welcomeページを下にスクロールすると白い余白が現れる不具合があったため、子要素のサイズを可変(最小値100vh, 100vw)に設定することで不具合を解消した。

## 動作確認

<!--
- どのような動作確認をしたのか？見つかった課題等はあるか？
-->
- 背景画像が途切れなくなった

## その他

<!--
- 伝えておくべき事や，補足資料などがあれば自由に記載して下さい
-->