### PR TITLE
不規則な動きの敵とバッタを倒した時のスコアを変更した

### DIFF
--- a/frontend/src/features/game/constants/Enemies.ts
+++ b/frontend/src/features/game/constants/Enemies.ts
@@ -38,7 +38,7 @@ export const RED_CATERPILLAR: EnemyEntity = {
 export const ERROR_CATERPILLAR: EnemyEntity = {
     name: "error-caterpillar-sprite",
     velocityX: 80,
-    point: 130,
+    point: 150,
     frameWidth: 30,
     frameHeight: 8,
     frameRate: 8,
@@ -47,7 +47,7 @@ export const ERROR_CATERPILLAR: EnemyEntity = {
 export const GRASSHOPPER: EnemyEntity = {
     name: "grasshopper-sprite",
     velocityX: 100,
-    point: 150,
+    point: 200,
     frameWidth: 23,
     frameHeight: 12,
     frameRate: 2,


### PR DESCRIPTION
## 関連
https://github.com/Obanyan2023/susumukun/issues/135
<!--
- 関連するPull request, Issueなど
-->

## 変更の概要
不規則な動きをする敵のスコアを150、バッタのスコアを200に変更した
<!--
- 変更の概要を選択してください
- 複数選択可
 -->

-   [x] フロントエンド
-   [ ] バックエンド
-   [ ] 機能関連
-   [ ] バグ修正
-   [ ] リファクタリング
-   [ ] ドキュメント
-   [ ] その他

## 変更の詳細

<!--
- 変更の詳細をなるべく具体的に記載して下さい
 -->

## 動作確認

<!--
- どのような動作確認をしたのか？見つかった課題等はあるか？
-->

## その他

<!--
- 伝えておくべき事や，補足資料などがあれば自由に記載して下さい
-->