### PR TITLE
チャレンジモード選択可能条件の作成

### DIFF
--- a/frontend/src/features/game/constants/localStorageKeys.ts
+++ b/frontend/src/features/game/constants/localStorageKeys.ts
@@ -6,3 +6,6 @@ export const DIFFICULTY = "difficulty";
 
 // チャレンジモードに挑戦可能かどうかを保存するためのキー
 export const CAN_CHALLENGE = "canChallenge";
+
+// チャレンジモード解禁時の通知用フラグを保存するためのキー
+export const CHA_CHALLENGE_NOTIFICATION = "chaChallengeNotification";

--- a/frontend/src/features/game/constants/localStorageKeys.ts
+++ b/frontend/src/features/game/constants/localStorageKeys.ts
@@ -3,3 +3,6 @@ export const NICKNAME = "nickname";
 
 // 難易度を保存するためのキー
 export const DIFFICULTY = "difficulty";
+
+// チャレンジモードに挑戦可能かどうかを保存するためのキー
+export const CAN_CHALLENGE = "canChallenge";

--- a/frontend/src/features/game/scenes/GameEndScene.ts
+++ b/frontend/src/features/game/scenes/GameEndScene.ts
@@ -5,9 +5,9 @@ import GameClearImage from "../components/images/GameClearImage";
 import { storeScoresApi } from "../../scores/api";
 import TimeOverImage from "../components/images/TimeOverImage";
 import { is_set } from "../../../utils/isType";
-import { DIFFICULTY, NICKNAME } from "../constants/localStorageKeys";
+import {CAN_CHALLENGE, DIFFICULTY, NICKNAME} from "../constants/localStorageKeys";
 import ContinueButton from "../components/buttons/ContinueButton";
-import {CHALLENGE} from "../constants/DifficultyLevel";
+import {CHALLENGE, HARD} from "../constants/DifficultyLevel";
 
 export default class GameEndScene extends Phaser.Scene {
   /**
@@ -29,6 +29,11 @@ export default class GameEndScene extends Phaser.Scene {
    * @var スコア
    */
   protected score: number = 0;
+
+  /**
+   * @var チャレンジモードに挑戦するためのスコア
+   */
+  protected challengeScore: number = 2000;
 
   /**
    * コンストラクタ
@@ -97,6 +102,10 @@ export default class GameEndScene extends Phaser.Scene {
 
     if (CHALLENGE.SEED === difficulty) {
       return;
+    }
+
+    if (HARD.SEED === difficulty && this.score >= this.challengeScore && this.gameEndImage instanceof GameClearImage) {
+      localStorage.setItem(CAN_CHALLENGE, "true");
     }
 
     storeScoresApi(nickname ?? "名無し", this.score, difficulty);

--- a/frontend/src/features/game/scenes/GameEndScene.ts
+++ b/frontend/src/features/game/scenes/GameEndScene.ts
@@ -104,10 +104,13 @@ export default class GameEndScene extends Phaser.Scene {
       return;
     }
 
+    storeScoresApi(nickname ?? "名無し", this.score, difficulty);
+
     if (HARD.SEED === difficulty && this.score >= this.challengeScore && this.gameEndImage instanceof GameClearImage) {
       localStorage.setItem(CAN_CHALLENGE, "true");
-    }
 
-    storeScoresApi(nickname ?? "名無し", this.score, difficulty);
+      alert("チャレンジモードに挑戦できるようになりました！");
+      window.location.reload();
+    }
   }
 }

--- a/frontend/src/features/game/scenes/GameEndScene.ts
+++ b/frontend/src/features/game/scenes/GameEndScene.ts
@@ -4,7 +4,7 @@ import GameOverImage from "../components/images/GameOverImage";
 import GameClearImage from "../components/images/GameClearImage";
 import { storeScoresApi } from "../../scores/api";
 import TimeOverImage from "../components/images/TimeOverImage";
-import { is_set } from "../../../utils/isType";
+import {customBoolean, is_set} from "../../../utils/isType";
 import {CAN_CHALLENGE, DIFFICULTY, NICKNAME} from "../constants/localStorageKeys";
 import ContinueButton from "../components/buttons/ContinueButton";
 import {CHALLENGE, HARD} from "../constants/DifficultyLevel";
@@ -106,11 +106,14 @@ export default class GameEndScene extends Phaser.Scene {
 
     storeScoresApi(nickname ?? "名無し", this.score, difficulty);
 
-    if (HARD.SEED === difficulty && this.score >= this.challengeScore && this.gameEndImage instanceof GameClearImage) {
+    if (HARD.SEED === difficulty && this.score >= this.challengeScore && this.gameEndImage instanceof GameClearImage &&  !customBoolean(localStorage.getItem(CAN_CHALLENGE))) {
       localStorage.setItem(CAN_CHALLENGE, "true");
+      this.tmpButton.object?.destroy();
+      this.continueButton.object?.destroy();
 
-      alert("チャレンジモードに挑戦できるようになりました！");
-      window.location.reload();
+      setTimeout(() => {
+        window.location.reload();
+      }, 1000);
     }
   }
 }

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -17,8 +17,14 @@ import { GameComponent } from "../components/Game";
 import Select from '@mui/material/Select';
 import { SelectChangeEvent } from '@mui/material/Select/SelectInput';
 import {CHALLENGE, DIFFICULTY_LEVELS, DifficultyLevel, NORMAL} from "../features/game/constants/DifficultyLevel";
-import {CAN_CHALLENGE, DIFFICULTY, NICKNAME} from "../features/game/constants/localStorageKeys";
+import {
+    CAN_CHALLENGE,
+    CHA_CHALLENGE_NOTIFICATION,
+    DIFFICULTY,
+    NICKNAME
+} from "../features/game/constants/localStorageKeys";
 import {customBoolean} from "../utils/isType";
+import {useEffect} from "react";
 
 const style = {
     position: 'absolute' as 'absolute',
@@ -89,6 +95,15 @@ export const Home = () => {
         localStorage.setItem(DIFFICULTY, String(difficult));
         setIsFullScreen(!isFullScreen);
     }
+
+    useEffect(() => {
+        setTimeout(() => {
+            if (customBoolean(localStorage.getItem(CAN_CHALLENGE)) && !customBoolean(localStorage.getItem(CHA_CHALLENGE_NOTIFICATION))) {
+                localStorage.setItem(CHA_CHALLENGE_NOTIFICATION, "true");
+                alert(`チャレンジモードが解放されました！\n難易度を「${CHALLENGE.NAME}」に変更してみてください！`);
+            }
+        }, 100);
+    }, []);
 
     const HomeComponent = () => (
         <Box sx={image}>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -16,8 +16,9 @@ import '../index.css';
 import { GameComponent } from "../components/Game";
 import Select from '@mui/material/Select';
 import { SelectChangeEvent } from '@mui/material/Select/SelectInput';
-import { DIFFICULTY_LEVELS, DifficultyLevel, NORMAL } from "../features/game/constants/DifficultyLevel";
-import { DIFFICULTY, NICKNAME } from "../features/game/constants/localStorageKeys";
+import {CHALLENGE, DIFFICULTY_LEVELS, DifficultyLevel, NORMAL} from "../features/game/constants/DifficultyLevel";
+import {CAN_CHALLENGE, DIFFICULTY, NICKNAME} from "../features/game/constants/localStorageKeys";
+import {customBoolean} from "../utils/isType";
 
 const style = {
     position: 'absolute' as 'absolute',
@@ -103,8 +104,12 @@ export const Home = () => {
                         <FormControl>
                             <InputLabel id="a-label">難易度</InputLabel>
                             <Select labelId="a-label" id="a" sx={{ bgcolor: "white" }} onChange={handleChange} value={difficult} label="Age">
-                                {DIFFICULTY_LEVELS.map((LEVEL: DifficultyLevel) => {
-                                    return <MenuItem value={LEVEL.SEED}>{LEVEL.NAME}</MenuItem>
+                                {DIFFICULTY_LEVELS.map((LEVEL: DifficultyLevel): JSX.Element | null => {
+                                    if (LEVEL.SEED !== CHALLENGE.SEED || customBoolean(localStorage.getItem(CAN_CHALLENGE))) {
+                                        return <MenuItem value={LEVEL.SEED}>{LEVEL.NAME}</MenuItem>
+                                    }
+
+                                    return null;
                                 })}
                             </Select>
                         </FormControl>

--- a/frontend/src/utils/isType.ts
+++ b/frontend/src/utils/isType.ts
@@ -7,3 +7,15 @@
 export function is_set<T>(value: unknown): value is T {
   return value !== undefined && value !== null;
 }
+
+export function is_string(value: unknown): value is string {
+    return typeof value === "string";
+}
+
+export function customBoolean(value: unknown): boolean {
+  if (is_string(value)) {
+    return value === "true";
+  }
+
+  return false;
+}


### PR DESCRIPTION
## 関連

- #142 

## 変更の概要

<!--
- 変更の概要を選択してください
- 複数選択可
 -->

-   [x] フロントエンド
-   [ ] バックエンド
-   [x] 機能関連
-   [ ] バグ修正
-   [ ] リファクタリング
-   [ ] ドキュメント
-   [ ] その他

## 変更の詳細

- ハードモード・スコア2000以上・ゲームリアを達成時にチャレンジモードを選択可能に

## 動作確認

- 条件を満たした際にチャレンジモードが選択可能になり，選択するとチャレンジモードで遊べることを確認

## その他

なし