### PR TITLE
横画面化処理に失敗した際にユーザに伝える

### DIFF
--- a/frontend/src/components/Game/index.tsx
+++ b/frontend/src/components/Game/index.tsx
@@ -1,24 +1,17 @@
 import Phaser from "phaser"
 import React from "react";
 import { config } from "../../features/game/index";
-import { is_set } from "../../utils/isType";
+import {customBoolean, is_set} from "../../utils/isType";
+import {PLAYING} from "../../features/game/constants/localStorageKeys";
 
 export const GameComponent = () => {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const [game, setGame] = React.useState<Phaser.Game | null>(null);
-    const screenOrientation = window.screen.orientation;
-
-    // 画面を横向きに固定
-    if (is_set(screenOrientation) && (screenOrientation as any).lock) {
-        // @ts-ignore
-        (screenOrientation as any).lock('landscape')
-            .catch((error: unknown) => {
-                //
-            });
-    }
 
     React.useEffect(() => {
         const game = new Phaser.Game(config);
+
+        localStorage.setItem(PLAYING, "true");
+
         window.addEventListener('resize', () => {
             try {
                 game.scale.setGameSize(window.innerWidth, window.innerHeight);

--- a/frontend/src/features/game/constants/localStorageKeys.ts
+++ b/frontend/src/features/game/constants/localStorageKeys.ts
@@ -9,3 +9,8 @@ export const CAN_CHALLENGE = "canChallenge";
 
 // チャレンジモード解禁時の通知用フラグを保存するためのキー
 export const CHA_CHALLENGE_NOTIFICATION = "chaChallengeNotification";
+
+// 画面の向きを固定するためのフラグを保存するためのキー
+export const TRY_ORIENTATION_LOCK = "tryOrientationLock";
+
+export const PLAYING = "playing";

--- a/frontend/src/utils/Orientations.ts
+++ b/frontend/src/utils/Orientations.ts
@@ -1,0 +1,51 @@
+import {customBoolean, is_set} from "./isType";
+import {TRY_ORIENTATION_LOCK} from "../features/game/constants/localStorageKeys";
+
+/**
+ * 画面が縦向きかどうかを返す
+ *
+ * @returns {boolean} 画面が縦向きかどうか
+ */
+export function isLandscape(): boolean {
+    const angle = window.orientation ?? window.screen.orientation.angle;
+
+    if (angle === 90 || angle === 90 * -1) {
+        return true;
+    }
+
+    return false;
+}
+
+/**
+ * 画面を横向きにする
+ * 画面を横向きにできなかったらアラートを出す
+ *
+ * @returns {boolean} 画面を横向きにできたかどうか
+ */
+export function setLandscape(): boolean {
+    const msg = "画面を横向きにして遊んでください";
+
+    // すでに横向きなら何もしない
+    if (isLandscape() || customBoolean(localStorage.getItem(TRY_ORIENTATION_LOCK))) {
+        return true;
+    }
+
+    // 画面を横向きにする
+    try {
+        // 複数回呼ばれるのを防ぐためにフラグを立てる
+        localStorage.setItem(TRY_ORIENTATION_LOCK, "true");
+
+        // 画面を横向きにする
+        (window.screen.orientation as any).lock("landscape").catch(() => {
+            // IOSでないかつ画面を横向きにできなかったらアラートを出し画面をリロードする
+            alert(msg);
+            window.location.reload();
+        });
+
+        return true;
+    } catch (e) {
+        // 画面を横向きにできなかったらアラートを出す
+        alert(msg);
+        return false;
+    }
+}


### PR DESCRIPTION
## 関連

- #114 

## 変更の概要

<!--
- 変更の概要を選択してください
- 複数選択可
 -->

-   [x] フロントエンド
-   [ ] バックエンド
-   [x] 機能関連
-   [ ] バグ修正
-   [ ] リファクタリング
-   [ ] ドキュメント
-   [ ] その他

## 変更の詳細

- 横画面にする処理が失敗した際に `alert` が出るように変更
- 画面の方向が変わった際にゲーム画面を正常にするため画面の再読込を行う

## 動作確認

- 横画面にする必要が無いPC画面では何もアラートが出ないことを確認
- 横画面にする処理が問題無く行われた際には何もアラートが出ないことを確認
- 横画面にする処理が失敗した際には横画面にするまでアラートが表示されることを確認

## その他

なし