### PR TITLE
デプロイに利用されるブランチを明示的に main へと変更

### DIFF
--- a/.github/workflows/vercel.yaml
+++ b/.github/workflows/vercel.yaml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: main
       #  your build commands
       # - run: |
       #    ng build --prod


### PR DESCRIPTION
## 関連

- #162 

## 変更の概要

<!--
- 変更の概要を選択してください
- 複数選択可
 -->

-   [ ] フロントエンド
-   [ ] バックエンド
-   [ ] 機能関連
-   [x] バグ修正
-   [ ] リファクタリング
-   [ ] ドキュメント
-   [x] その他

## 変更の詳細

- デプロイに利用されているブランチが開発用ブランチである `develop` になっていたので，`main` ブランチとなるように変更

## 動作確認

- GitHub Actions に関する変更のため確認できない

## その他

なし