### PR TITLE
チャレンジモードの存在がわかるようにする

### DIFF
--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -101,6 +101,11 @@ export const Home = () => {
     const handleClose = () => setOpen(false);
 
     const handleChange = (event: SelectChangeEvent<number>) => {
+        if (event.target.value as number === CHALLENGE.SEED && !customBoolean(localStorage.getItem(CAN_CHALLENGE))) {
+            alert("チャレンジモードはまだ解放されていません！\nHardモードでスコア2000点以上を目指してください！")
+            return;
+        }
+
         setDifficult(event.target.value as number);
     };
 
@@ -154,11 +159,24 @@ export const Home = () => {
                             <InputLabel id="a-label">難易度</InputLabel>
                             <Select labelId="a-label" id="a" sx={{ bgcolor: "white" }} onChange={handleChange} value={difficult} label="Age">
                                 {DIFFICULTY_LEVELS.map((LEVEL: DifficultyLevel, index: number): JSX.Element | null => {
-                                    if (LEVEL.SEED !== CHALLENGE.SEED || customBoolean(localStorage.getItem(CAN_CHALLENGE))) {
-                                        return <MenuItem key={index} value={LEVEL.SEED}>{LEVEL.NAME}</MenuItem>
-                                    }
+                                    const style = () => {
+                                        if (LEVEL.SEED !== CHALLENGE.SEED || customBoolean(localStorage.getItem(CAN_CHALLENGE))) {
+                                            return {};
+                                        }
+                                        return {
+                                            ":hover": {
+                                                color: "#aaa",
+                                                backgroundColor: "#fff"
+                                            },
+                                            color: "#aaa",
+                                        };
+                                    };
 
-                                    return null;
+                                    return (
+                                        <MenuItem key={index} value={LEVEL.SEED} sx={style}>
+                                            {LEVEL.NAME}
+                                        </MenuItem>
+                                    );
                                 })}
                             </Select>
                         </FormControl>


### PR DESCRIPTION
## 関連

- #157 

## 変更の概要

<!--
- 変更の概要を選択してください
- 複数選択可
 -->

-   [x] フロントエンド
-   [ ] バックエンド
-   [x] 機能関連
-   [ ] バグ修正
-   [ ] リファクタリング
-   [ ] ドキュメント
-   [ ] その他

## 変更の詳細

- 挑戦権がなくてもチャレンジモードをセレクトボックスに表示
- 挑戦権がない場合は `disabled` 風なスタイルに
- 挑戦権がない場合はクリック時に `alert`

## 動作確認

- 挑戦権がなくてもチャレンジモードがセレクトボックスに表示されていることを確認
- 挑戦権がなければクリックしても `alert` が出るだけで選択・挑戦できないことを確認
- 挑戦権を獲得後、`disabled` 風なスタイルでなくなり選択・挑戦が可能なことを確認

## その他

なし